### PR TITLE
Feature/common combinecocoa

### DIFF
--- a/travelPlan/.swiftlint.yml
+++ b/travelPlan/.swiftlint.yml
@@ -13,3 +13,10 @@ disabled_rules:
 line_length:
   ignores_comments: true
 
+nesting:
+  type_level:
+    warning: 3
+    error: 6
+  statement_level:
+    warning: 5
+    error: 10

--- a/travelPlan/Source/Common/CombineCocoa/UIButton+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIButton+Combine.swift
@@ -5,4 +5,14 @@
 //  Created by 양승현 on 2023/05/01.
 //
 
-import Foundation
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+public extension UIButton {
+  var tap: AnyPublisher<Void, Never> {
+    publihser(for: .touchUpInside)
+      .map { _ in }
+      .eraseToAnyPublisher()
+  }
+}

--- a/travelPlan/Source/Common/CombineCocoa/UIButton+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIButton+Combine.swift
@@ -1,0 +1,8 @@
+//
+//  UIButton+Combine.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/01.
+//
+
+import Foundation

--- a/travelPlan/Source/Common/CombineCocoa/UIControl+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIControl+Combine.swift
@@ -11,7 +11,9 @@ import Combine
 @available(iOS 13.0, *)
 extension UIControl {
   /// A publihser emitting events.
-  func publihser(for event: UIControl.Event) -> UIControl.InteractionPublihser {
+  func publihser(
+    for event: UIControl.Event
+  ) -> UIControl.InteractionPublihser {
     return InteractionPublihser(control: self, event: event)
   }
 }

--- a/travelPlan/Source/Common/CombineCocoa/UIControl+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIControl+Combine.swift
@@ -1,0 +1,17 @@
+//
+//  UIControl+Combine.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/01.
+//
+
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+extension UIControl {
+  /// A publihser emitting events.
+  func publihser(for event: UIControl.Event) -> UIControl.InteractionPublihser {
+    return InteractionPublihser(control: self, event: event)
+  }
+}

--- a/travelPlan/Source/Common/CombineCocoa/UIControl+CombineInteraction.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIControl+CombineInteraction.swift
@@ -13,8 +13,7 @@ extension UIControl {
   
   // MARK: - InteractionSubscription
   class InteractionSubscription<S: Subscriber>: Subscription
-  where S.Input == UIControl
-  {
+  where S.Input == UIControl {
     private var subscriber: S?
     private let control: UIControl
     private let event: UIControl.Event
@@ -58,7 +57,9 @@ extension UIControl {
     }
     
     // MARK: - Publihser
-    func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, UIControl == S.Input {
+    func receive<S>(subscriber: S)
+    where S: Subscriber,
+          Never == S.Failure, UIControl == S.Input {
       let subscription = InteractionSubscription(
         subscriber: subscriber,
         control: control,

--- a/travelPlan/Source/Common/CombineCocoa/UIControl+CombineInteraction.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UIControl+CombineInteraction.swift
@@ -1,0 +1,70 @@
+//
+//  UIControl+CombineInteraction.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/01.
+//
+
+import UIKit
+import Combine
+
+// MARK: - CombineInteraction
+extension UIControl {
+  
+  // MARK: - InteractionSubscription
+  class InteractionSubscription<S: Subscriber>: Subscription
+  where S.Input == UIControl
+  {
+    private var subscriber: S?
+    private let control: UIControl
+    private let event: UIControl.Event
+    
+    init(
+      subscriber: S,
+      control: UIControl,
+      event: UIControl.Event
+    ) {
+      self.subscriber = subscriber
+      self.control = control
+      self.event = event
+      
+      self.control.addTarget(self, action: #selector(handleEvent), for: event)
+    }
+    
+    @objc func handleEvent(_ sender: UIControl) {
+      _=self.subscriber?.receive(control)
+    }
+    
+    // MARK: - Subscription
+    func request(_ demand: Subscribers.Demand) {}
+    
+    func cancel() {
+      subscriber = nil
+      control.removeTarget(self, action: #selector(handleEvent), for: event)
+    }
+  }
+  
+  // MARK: - InteractionPublihser
+  struct InteractionPublihser: Publisher {
+    typealias Output = UIControl
+    typealias Failure = Never
+    
+    private let control: UIControl
+    private let event: UIControl.Event
+    
+    init(control: UIControl, event: UIControl.Event) {
+      self.control = control
+      self.event = event
+    }
+    
+    // MARK: - Publihser
+    func receive<S>(subscriber: S) where S : Subscriber, Never == S.Failure, UIControl == S.Input {
+      let subscription = InteractionSubscription(
+        subscriber: subscriber,
+        control: control,
+        event: event)
+      
+      subscriber.receive(subscription: subscription)
+    }
+  }
+}

--- a/travelPlan/Source/Common/CombineCocoa/UISwitch+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UISwitch+Combine.swift
@@ -5,4 +5,15 @@
 //  Created by 양승현 on 2023/05/01.
 //
 
-import Foundation
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+extension UISwitch {
+  /// A publihser emitting any text changes
+  var changed: AnyPublisher<Bool, Never> {
+    publihser(for: .editingChanged)
+      .compactMap { ($0 as? UISwitch)?.isOn }
+      .eraseToAnyPublisher()
+  }
+}

--- a/travelPlan/Source/Common/CombineCocoa/UISwitch+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UISwitch+Combine.swift
@@ -1,0 +1,8 @@
+//
+//  UISwitch+Combine.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/01.
+//
+
+import Foundation

--- a/travelPlan/Source/Common/CombineCocoa/UITextField+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UITextField+Combine.swift
@@ -5,4 +5,23 @@
 //  Created by 양승현 on 2023/05/01.
 //
 
-import Foundation
+import UIKit
+import Combine
+
+@available(iOS 13.0, *)
+extension UITextField {
+  /// A publihser emitting any text changes to this text field.
+  var changed: AnyPublisher<String, Never> {
+    publihser(for: .editingChanged)
+      .compactMap { ($0 as? UITextField)?.text }
+      .eraseToAnyPublisher()
+  }
+  
+  /// A publisher that emits whenever the user taps the **return button**
+  /// and **ends the editing** on the text field.
+  var returnPublisher: AnyPublisher<Void, Never> {
+    publihser(for: .editingDidEndOnExit)
+      .map {_ in}
+      .eraseToAnyPublisher()
+  }
+}

--- a/travelPlan/Source/Common/CombineCocoa/UITextField+Combine.swift
+++ b/travelPlan/Source/Common/CombineCocoa/UITextField+Combine.swift
@@ -1,0 +1,8 @@
+//
+//  UITextField+Combine.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/01.
+//
+
+import Foundation

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		15F0A3F929FD5CBA0049AB33 /* LayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F0A3F829FD5CBA0049AB33 /* LayoutSupport.swift */; };
 		15F0A3FC29FD5D2C0049AB33 /* ConvenienceInit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F0A3FB29FD5D2C0049AB33 /* ConvenienceInit.swift */; };
 		15F0A3FE29FD5DF00049AB33 /* ViewModelProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15F0A3FD29FD5DF00049AB33 /* ViewModelProtocols.swift */; };
+		15FA5BB029FF1A2A00649317 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FA5BAB29FF1A2900649317 /* UIControl+Combine.swift */; };
+		15FA5BB129FF1A2A00649317 /* UISwitch+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FA5BAC29FF1A2900649317 /* UISwitch+Combine.swift */; };
+		15FA5BB229FF1A2A00649317 /* UIButton+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FA5BAD29FF1A2900649317 /* UIButton+Combine.swift */; };
+		15FA5BB329FF1A2A00649317 /* UIControl+CombineInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FA5BAE29FF1A2900649317 /* UIControl+CombineInteraction.swift */; };
+		15FA5BB429FF1A2A00649317 /* UITextField+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FA5BAF29FF1A2900649317 /* UITextField+Combine.swift */; };
 		8B8277C1D53D2763DBC91C26 /* Pods_travelPlan.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5093F957BE61B8938FD9727 /* Pods_travelPlan.framework */; };
 /* End PBXBuildFile section */
 
@@ -35,6 +40,11 @@
 		15F0A3F829FD5CBA0049AB33 /* LayoutSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutSupport.swift; sourceTree = "<group>"; };
 		15F0A3FB29FD5D2C0049AB33 /* ConvenienceInit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConvenienceInit.swift; sourceTree = "<group>"; };
 		15F0A3FD29FD5DF00049AB33 /* ViewModelProtocols.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModelProtocols.swift; sourceTree = "<group>"; };
+		15FA5BAB29FF1A2900649317 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
+		15FA5BAC29FF1A2900649317 /* UISwitch+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UISwitch+Combine.swift"; sourceTree = "<group>"; };
+		15FA5BAD29FF1A2900649317 /* UIButton+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIButton+Combine.swift"; sourceTree = "<group>"; };
+		15FA5BAE29FF1A2900649317 /* UIControl+CombineInteraction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+CombineInteraction.swift"; sourceTree = "<group>"; };
+		15FA5BAF29FF1A2900649317 /* UITextField+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UITextField+Combine.swift"; sourceTree = "<group>"; };
 		95C1136D7650708D46BBF977 /* Pods-travelPlan.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-travelPlan.release.xcconfig"; path = "Target Support Files/Pods-travelPlan/Pods-travelPlan.release.xcconfig"; sourceTree = "<group>"; };
 		B40897DD36F55524D37767A7 /* Pods-travelPlan.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-travelPlan.debug.xcconfig"; path = "Target Support Files/Pods-travelPlan/Pods-travelPlan.debug.xcconfig"; sourceTree = "<group>"; };
 		D5093F957BE61B8938FD9727 /* Pods_travelPlan.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_travelPlan.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -137,6 +147,7 @@
 		15F0A3F629FD5C9A0049AB33 /* Common */ = {
 			isa = PBXGroup;
 			children = (
+				15FA5BAA29FF1A2900649317 /* CombineCocoa */,
 				1339DB8429FD6B440039DF1D /* Extension */,
 				15F0A3F729FD5CAA0049AB33 /* Protocol */,
 			);
@@ -151,6 +162,18 @@
 				15F0A3FD29FD5DF00049AB33 /* ViewModelProtocols.swift */,
 			);
 			path = Protocol;
+			sourceTree = "<group>";
+		};
+		15FA5BAA29FF1A2900649317 /* CombineCocoa */ = {
+			isa = PBXGroup;
+			children = (
+				15FA5BAB29FF1A2900649317 /* UIControl+Combine.swift */,
+				15FA5BAC29FF1A2900649317 /* UISwitch+Combine.swift */,
+				15FA5BAD29FF1A2900649317 /* UIButton+Combine.swift */,
+				15FA5BAE29FF1A2900649317 /* UIControl+CombineInteraction.swift */,
+				15FA5BAF29FF1A2900649317 /* UITextField+Combine.swift */,
+			);
+			path = CombineCocoa;
 			sourceTree = "<group>";
 		};
 		22C6F6C53B2A988070A2BBBC /* Pods */ = {
@@ -304,8 +327,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15FA5BB429FF1A2A00649317 /* UITextField+Combine.swift in Sources */,
+				15FA5BB329FF1A2A00649317 /* UIControl+CombineInteraction.swift in Sources */,
+				15FA5BB229FF1A2A00649317 /* UIButton+Combine.swift in Sources */,
 				1594F53629FD517E00A58F20 /* ViewController.swift in Sources */,
+				15FA5BB029FF1A2A00649317 /* UIControl+Combine.swift in Sources */,
 				1339DB8629FD6C240039DF1D /* UIColor+.swift in Sources */,
+				15FA5BB129FF1A2A00649317 /* UISwitch+Combine.swift in Sources */,
 				15F0A3FE29FD5DF00049AB33 /* ViewModelProtocols.swift in Sources */,
 				15F0A3F929FD5CBA0049AB33 /* LayoutSupport.swift in Sources */,
 				1594F54C29FD52BF00A58F20 /* test.swift in Sources */,


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- Commin 폴더에 Combine cocoa 기능을 추가했습니다.
- Swiftlint 기능 추가했어요.

## ✨ [작업 내용]

UIControl 에 컴바인 subscription, publihser 구현 후 UIContorl 컴포넌트 UIButton, UITextFeild등에 편의 사용할 수 있도록 추가했습니다. 추후 기능 더 추가하면 될 것 같아요.

swiftlint 런 스크립트에서 "Nesting violation. Types should be nested at most 1 level deep" 경고가 떴습니다.

![image](https://user-images.githubusercontent.com/96910404/235378234-327a121c-03e1-42f0-b6aa-e261e105a6fb.png)

요기에 typealias 라인에서 위와 같은 경고가 떠서 아래 첨부한 스택 오버플로우 글을 통해 3 level deep으로 변경했어요.

## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

참고한 내용1 : Observe UIButton Event Using Combine ( <a href="https://betterprogramming.pub/observe-uibutton-events-using-combine-in-swift-5-63c1a4e0a0c1">medium 포스트 링크</a>)

참고한 내용2 : Nesting violation... ( <a href="https://stackoverflow.com/questions/46766682/nesting-violation-types-should-be-nested-at-most-1-level-deep">stackoverflow 포스트 링크</a> )
