### PR TITLE
Feature/feed category page view

### DIFF
--- a/travelPlan/Source/Feature/Feed/Constant/CategoryConstant.swift
+++ b/travelPlan/Source/Feature/Feed/Constant/CategoryConstant.swift
@@ -1,0 +1,86 @@
+//
+//  CategoryConstant.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+
+// MARK: - CategoryView UI constants
+/// size가 고정이 아닌 경우는 shared를 통해서 얻어야 합니다.
+struct CategoryViewConstant {
+  
+  /// Size얻기 위해 사용되는 인스턴스
+  static var shared = CategoryViewConstant()
+  
+  /// CategoryViewCellUIConstants
+  var cellSize: CGSize {
+    CategoryViewCellConstant.shared.cellSize
+  }
+  
+  /// height = cell height + scrollBar height.
+  var intrinsicContentSize: CGSize {
+    let width = cellSize.width
+    let height = cellSize.height + CategoryViewConstant.ScrollBar.height
+    return CGSize(width: width, height: height)
+  }
+  
+  enum ScrollBar {
+    static let height: CGFloat = 4
+    static let radius: CGFloat = 2
+  }
+  
+  fileprivate init() {}
+  
+}
+
+// MARK: - CategoryViewCell UI constants
+struct CategoryViewCellConstant {
+  /// content size얻고 싶을 때.
+  static var shared = CategoryViewCellConstant()
+  
+  enum ImageView {
+    static let spacingTop: CGFloat = 20
+    static let spacingLeft: CGFloat = 27.5
+    static let size: CGSize = CGSize(width: 28, height: 28)
+  }
+  
+  enum Title {
+    static let spacingTop: CGFloat = 5
+    static let fontSize: CGFloat = 12
+    static let spacingBottom: CGFloat = 6
+    static let height: CGFloat = 22
+  }
+  
+  var cellSize: CGSize {
+    CGSize(
+      width: CategoryViewCellConstant.shared.cellWidth,
+      height: CategoryViewCellConstant.shared.cellHeight)
+  }
+  
+  /// Cell's intrinsic content width
+  fileprivate lazy var cellWidth: CGFloat = {
+    return ImageView.spacingLeft*2.0 + ImageView.size.width
+  }()
+  
+  /// Cell's intrinsic content height
+  fileprivate lazy var cellHeight: CGFloat = {
+    return (
+      ImageView.spacingTop +
+      ImageView.size.height +
+      Title.spacingTop +
+      Title.height +
+      Title.spacingBottom)
+  }()
+  
+  fileprivate init() {}
+}
+
+// MARK: - CategoryDetailViewCell UI constants
+struct CategoryDetailCellConstant {
+  static let spacingTop: CGFloat = 17.5
+  
+  fileprivate init() {}
+}

--- a/travelPlan/Source/Feature/Feed/Constant/CategoryConstant.swift
+++ b/travelPlan/Source/Feature/Feed/Constant/CategoryConstant.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-
 // MARK: - CategoryView UI constants
 /// size가 고정이 아닌 경우는 shared를 통해서 얻어야 합니다.
 struct CategoryViewConstant {

--- a/travelPlan/Source/Feature/Feed/Model/CategoryModel.swift
+++ b/travelPlan/Source/Feature/Feed/Model/CategoryModel.swift
@@ -1,0 +1,15 @@
+//
+//  CategoryModel.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+let categoryData = [
+  "카테고리1", "카리2", "카테고리3333",
+  "카테고리4", "카테고리5", "카테고리6", "카테고리7777"]
+
+enum CategoryViewType {
+  case category
+  case categoryDetail
+}

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailView.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 final class CategoryDetailView: UICollectionView {
   // MARK: - Properties
+  /// CategoryView가 로드된 후 height가 지정되면 detailView cell의 height지정하기 위해
   private var layout: UICollectionViewFlowLayout!
   
   // MARK: - Initialization

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailView.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailView.swift
@@ -1,0 +1,48 @@
+//
+//  CategoryDetailView.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+final class CategoryDetailView: UICollectionView {
+  // MARK: - Properties
+  private var layout: UICollectionViewFlowLayout!
+  
+  // MARK: - Initialization
+  convenience init() {
+    let layoutObject = UICollectionViewFlowLayout()
+    layoutObject.minimumLineSpacing = 0
+    layoutObject.scrollDirection = .horizontal
+    self.init(
+      frame: .zero,
+      collectionViewLayout: layoutObject)
+    layout = layoutObject
+  }
+  
+  private override init(
+    frame: CGRect,
+    collectionViewLayout layout: UICollectionViewLayout
+  ) {
+    super.init(frame: frame, collectionViewLayout: layout)
+    translatesAutoresizingMaskIntoConstraints = false
+    showsHorizontalScrollIndicator = false
+    decelerationRate = .fast
+    register(
+      CategoryDetailViewCell.self,
+      forCellWithReuseIdentifier: CategoryDetailViewCell.id)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+// MARK: - Helpers
+extension CategoryDetailView {
+  func setLayoutItemSize(_ size: CGSize) {
+    layout.itemSize = size
+  }
+}

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailViewCell.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryDetailView/CategoryDetailViewCell.swift
@@ -1,0 +1,65 @@
+//
+//  CategoryDetailViewCell.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+class CategoryDetailViewCell: UICollectionViewCell {
+  // MARK: - Identifier
+  static let id = "CategoryDetailViewCell"
+  
+  // MARK: - Properties
+  let content = UIView().set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  // MARK: - Initialization
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+  
+  convenience init() {
+    self.init(frame: .zero)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+extension CategoryDetailViewCell {
+  func configCell(with indexPath: IndexPath) -> UICollectionViewCell {
+    backgroundColor = .systemPink
+      .withAlphaComponent(CGFloat((indexPath.row+1))*0.2)
+    return self
+  }
+}
+
+// MARK: - LayoutSupport
+extension CategoryDetailViewCell: LayoutSupport {
+  func addSubviews() {
+    contentView.addSubview(content)
+  }
+  
+  func setConstraints() {
+    NSLayoutConstraint.activate(contentConstraint)
+  }
+}
+
+fileprivate extension CategoryDetailViewCell {
+  var contentConstraint: [NSLayoutConstraint] {
+    [content.topAnchor.constraint(
+      equalTo: contentView.topAnchor,
+      constant: CategoryDetailCellConstant.spacingTop),
+     content.leadingAnchor.constraint(
+      equalTo: contentView.leadingAnchor),
+     content.trailingAnchor.constraint(
+      equalTo: contentView.trailingAnchor),
+     content.bottomAnchor.constraint(
+      equalTo: contentView.bottomAnchor)]
+  }
+}

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryPageView.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryPageView.swift
@@ -1,0 +1,180 @@
+//
+//  CategoryPageView.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+/// Horizontal category page view
+final class CategoryPageView: UIView {
+  
+  // MARK: - Properties
+  private lazy var categoryView = CategoryView()
+  private lazy var categoryDetailView = CategoryDetailView()
+  private let vm = CategoryPageViewModel()
+  
+  // MARK: - Initialization
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configure()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  convenience init() {
+    self.init(frame: .zero)
+  }
+  
+  override func layoutSubviews() {
+    initCategoryDetailViewCellItem()
+    initCategoryViewScrollBarLayout()
+    selectedCategoryViewFirstCell()
+  }
+}
+
+// MARK: - Helpers
+fileprivate extension CategoryPageView {
+  func configure() {
+    translatesAutoresizingMaskIntoConstraints = false
+    setupUI()
+    categoryView.delegate = self
+    categoryView.dataSource = self
+    categoryDetailView.dataSource = self
+  }
+  
+  /// If subviews layout, set category view scroll bar's layout
+  func initCategoryViewScrollBarLayout() {
+    let indexPath = IndexPath(row: 0, section: 0)
+    guard let cell = categoryView
+      .collectionView
+      .cellForItem(at: indexPath
+      ) as? CategoryViewCell else {
+      return
+    }
+    let firstCellTextSize = vm.titleFontSize()
+    let firstTextLeading = (
+      CategoryViewConstant
+        .shared
+        .intrinsicContentSize
+        .width - firstCellTextSize)/2
+    categoryView.drawScrollBar(
+      target: cell,
+      fromLeading: firstTextLeading)
+  }
+  
+  /// If subviews layout, set category detail view cell size
+  func initCategoryDetailViewCellItem() {
+    let categoryCellHeight = CategoryViewConstant
+      .shared
+      .intrinsicContentSize
+      .height
+    categoryDetailView.setLayoutItemSize(
+      CGSize(
+        width: bounds.width,
+        height: bounds.height - categoryCellHeight))
+    categoryDetailView.isScrollEnabled = false
+  }
+  
+  /// If subviews layout, selectItem category view first sell
+  func selectedCategoryViewFirstCell() {
+    categoryView.collectionView.selectItem(
+      at: IndexPath(row: 0, section: 0),
+      animated: false,
+      scrollPosition: .left)
+  }
+}
+
+// MARK: - UICollectionViewDataSource
+extension CategoryPageView: UICollectionViewDataSource {
+  func collectionView(
+    _ collectionView: UICollectionView,
+    numberOfItemsInSection section: Int
+  ) -> Int {
+    return categoryData.count
+  }
+  
+  func collectionView(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    switch collectionView {
+    case categoryDetailView:
+      return vm.configCell(
+        collectionView,
+        cellForItemAt: indexPath,
+        type: .categoryDetail)
+    default:
+      return vm.configCell(
+        collectionView,
+        cellForItemAt: indexPath,
+        type: .category)
+    }
+  }
+}
+
+// MARK: - UICollectionViewDelegate
+extension CategoryPageView: UICollectionViewDelegate {
+  
+  /// When selected category view's cell, set scrollBar postiion, cell's position in screen
+  func collectionView(
+    _ collectionView: UICollectionView,
+    didSelectItemAt indexPath: IndexPath
+  ) {
+    if collectionView == categoryView.collectionView {
+      let titleWidth = vm.titleFontSize(of: indexPath)
+      let spacing = vm.scrollBarLeadingSpacing(titleWidth)
+      
+      guard let cell = collectionView.cellForItem(at: indexPath) else { return }
+      
+      _=[collectionView, categoryDetailView]
+        .map {
+          $0.selectItem(
+            at: indexPath,
+            animated: true,
+            scrollPosition: .centeredHorizontally)
+        }
+      categoryView.drawScrollBar(target: cell, fromLeading: spacing)
+      UIView.animate(withDuration: 0.3) {
+        self.layoutIfNeeded()
+      }
+    }
+  }
+}
+
+// MARK: - LayoutSupport
+extension CategoryPageView: LayoutSupport {
+  func addSubviews() {
+    _=[categoryView,
+       categoryDetailView]
+      .map { addSubview($0) }
+  }
+  
+  func setConstraints() {
+    _=[categoryViewConstraint,
+       categoryDetailViewConstraint]
+      .map { NSLayoutConstraint.activate($0) }
+  }
+}
+
+fileprivate extension CategoryPageView {
+  var categoryViewConstraint: [NSLayoutConstraint] {
+    [categoryView.topAnchor.constraint(
+      equalTo: topAnchor),
+     categoryView.leadingAnchor.constraint(
+      equalTo: leadingAnchor),
+     categoryView.trailingAnchor.constraint(
+      equalTo: trailingAnchor),
+     categoryView.heightAnchor.constraint(equalToConstant: CategoryViewConstant.shared.intrinsicContentSize.height)]
+  }
+  
+  var categoryDetailViewConstraint: [NSLayoutConstraint] {
+    [categoryDetailView.topAnchor.constraint(equalTo: categoryView.bottomAnchor),
+     categoryDetailView.leadingAnchor.constraint(equalTo: leadingAnchor),
+     categoryDetailView.trailingAnchor.constraint(equalTo: trailingAnchor),
+     categoryDetailView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+  }
+}

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryView.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryView.swift
@@ -1,0 +1,159 @@
+//
+//  CategoryView.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+final class CategoryView: UIView {
+  // MARK: - Properties
+  private var scrollBarConstraints: [NSLayoutConstraint] = []
+  
+  private let categoryView = {
+    let layout = UICollectionViewFlowLayout()
+    layout.scrollDirection = .horizontal
+    layout.itemSize = CategoryViewConstant
+      .shared.cellSize
+    layout.minimumLineSpacing = 0
+    layout.minimumInteritemSpacing = 0
+    let cv = UICollectionView(
+      frame: .zero,
+      collectionViewLayout: layout)
+    cv.translatesAutoresizingMaskIntoConstraints = false
+    cv.decelerationRate = .fast
+    cv.showsHorizontalScrollIndicator = false
+    return cv
+  }()
+  
+  private let scrollBar: UIView = UIView().set {
+    $0.backgroundColor = UIColor(red: 0.106, green: 0.627, blue: 0.922, alpha: 1)
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.layer.cornerRadius = CategoryViewConstant.ScrollBar.radius
+  }
+  
+  var delegate: UICollectionViewDelegate? {
+    get {
+      return categoryView.delegate
+    } set {
+      categoryView.delegate = newValue
+    }
+  }
+  
+  var dataSource: UICollectionViewDataSource? {
+    get {
+      return categoryView.dataSource
+    } set {
+      categoryView.dataSource = newValue
+    }
+  }
+  
+  var collectionView: UICollectionView {
+    categoryView
+  }
+  
+  // MARK: - LifeCycle
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    translatesAutoresizingMaskIntoConstraints = false
+    setupUI()
+    categoryView.register(
+      CategoryViewCell.self,
+      forCellWithReuseIdentifier: CategoryViewCell.id)
+    categoryView.bounces = false
+    backgroundColor = .white
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  convenience init() {
+    self.init(frame: .zero)
+  }
+}
+
+// MARK: - Helpers
+extension CategoryView {
+  func drawScrollBar(target cell: UICollectionViewCell, fromLeading spacing: CGFloat) {
+    NSLayoutConstraint.deactivate(scrollBarConstraints)
+    scrollBarConstraints = scrollBarConstriant(cell, cellTitleSpacing: spacing)
+    NSLayoutConstraint.activate(scrollBarConstraints)
+  }
+}
+
+// MARK: - LayoutSupport
+extension CategoryView: LayoutSupport {
+  func addSubviews() {
+    _=[categoryView, scrollBar].map { addSubview($0) }
+  }
+  
+  func setConstraints() {
+    /// scrollBar position dynamic하게 바꾸기 위해 인스턴스에 저장
+    scrollBarConstraints = scrollBarConstriant()
+    _=[categoryViewConstraint,
+       scrollBarConstraints]
+      .map { NSLayoutConstraint.activate($0) }
+  }
+}
+
+fileprivate extension CategoryView {
+  var categoryViewConstraint: [NSLayoutConstraint] {
+    [categoryView.topAnchor.constraint(equalTo: topAnchor),
+     categoryView.leadingAnchor.constraint(equalTo: leadingAnchor),
+     categoryView.trailingAnchor.constraint(equalTo: trailingAnchor),
+     categoryView.heightAnchor.constraint(
+      equalToConstant: CategoryViewConstant.shared
+        .cellSize.height)]
+  }
+  
+  func scrollBarConstriant(
+    _ cell: UICollectionViewCell? = nil,
+    cellTitleSpacing spacing: CGFloat = 0.0
+  ) -> [NSLayoutConstraint] {
+    
+    var const = [
+      scrollBar.topAnchor.constraint(
+        lessThanOrEqualTo: categoryView.bottomAnchor),
+      scrollBar.heightAnchor.constraint(
+        lessThanOrEqualToConstant: CategoryViewConstant.ScrollBar.height),
+      scrollBar.bottomAnchor.constraint(equalTo: bottomAnchor)]
+    
+    guard let cell = cell else {
+      return setInitialScrollBar(constraint: &const)
+    }
+    
+    setScrollBarPosition(
+      from: cell,
+      spacing: spacing,
+      constraint: &const)
+    
+    return const
+  }
+  
+  func setInitialScrollBar(constraint: inout [NSLayoutConstraint]
+  ) -> [NSLayoutConstraint] {
+    let width = CategoryViewConstant.shared
+      .intrinsicContentSize
+      .width
+    _=[scrollBar.leadingAnchor.constraint(equalTo: leadingAnchor),
+       scrollBar.widthAnchor.constraint(equalToConstant: width)]
+      .map { constraint.append($0) }
+    return constraint
+  }
+  
+  func setScrollBarPosition(
+    from cell: UICollectionViewCell,
+    spacing: CGFloat,
+    constraint: inout [NSLayoutConstraint]
+  ) {
+    constraint.append(contentsOf: [
+      scrollBar.leadingAnchor.constraint(
+        equalTo: cell.leadingAnchor,
+        constant: spacing),
+      scrollBar.trailingAnchor.constraint(
+        equalTo: cell.trailingAnchor,
+        constant: -spacing)])
+  }
+}

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryView.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryView.swift
@@ -76,6 +76,10 @@ final class CategoryView: UIView {
 
 // MARK: - Helpers
 extension CategoryView {
+  /// selected cell위치에 따라 scrollBar layout 갱신
+  /// - Parameters:
+  ///   - cell: selected cell
+  ///   - spacing: celected cell's title text leading
   func drawScrollBar(target cell: UICollectionViewCell, fromLeading spacing: CGFloat) {
     NSLayoutConstraint.deactivate(scrollBarConstraints)
     scrollBarConstraints = scrollBarConstriant(cell, cellTitleSpacing: spacing)
@@ -132,6 +136,9 @@ fileprivate extension CategoryView {
     return const
   }
   
+  /// ScrollBar's leading, width anchor l
+  /// - Parameter constraint: scrollBar's default constraint array
+  /// - Returns: configured scrollBar's initial constraint
   func setInitialScrollBar(constraint: inout [NSLayoutConstraint]
   ) -> [NSLayoutConstraint] {
     let width = CategoryViewConstant.shared
@@ -143,6 +150,11 @@ fileprivate extension CategoryView {
     return constraint
   }
   
+  /// When called selectedItem in categoryView, set scroll bar's position
+  /// - Parameters:
+  ///   - cell: selectedItem
+  ///   - spacing: selected item's title from leading spacing
+  ///   - constraint: scrollBar's current constraint
   func setScrollBarPosition(
     from cell: UICollectionViewCell,
     spacing: CGFloat,

--- a/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryViewCell.swift
+++ b/travelPlan/Source/Feature/Feed/View/CategoryPageView/CategoryView/CategoryViewCell.swift
@@ -1,0 +1,127 @@
+//
+//  CategoryViewCell.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+class CategoryViewCell: UICollectionViewCell {
+  // MARK: - Idnentfier
+  static let id = "CategoryViewCell"
+  
+  // MARK: - Properties
+  let categoryImageView = UIImageView().set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.backgroundColor = .lightGray.withAlphaComponent(0.6)
+    $0.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+    $0.clipsToBounds = true
+  }
+  
+  let categoryTitle = UILabel().set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.font = UIFont.systemFont(
+      ofSize: CategoryViewCellConstant.Title.fontSize)
+    $0.textAlignment = .center
+    $0.textColor = UIColor(red: 0.404, green: 0.404, blue: 0.404, alpha: 1)
+    $0.text = "카테고리"
+  }
+  
+  override var isSelected: Bool {
+    willSet {
+      self.categoryTitle.textColor = newValue ? .black : UIColor(red: 0.404, green: 0.404, blue: 0.404, alpha: 1)
+      self.categoryImageView.backgroundColor = newValue ? .lightGray : .lightGray.withAlphaComponent(0.6)
+      if newValue {
+        selectedAnimation()
+      } else {
+        deselectedAnimation()
+      }
+    }
+  }
+  
+  // MARK: - Initialization
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    setupUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func prepareForReuse() {
+    isSelected = false
+    categoryImageView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+  }
+  
+  convenience init() {
+    self.init(frame: .zero)
+  }
+}
+
+// MARK: - Helpers
+extension CategoryViewCell {
+  func configUI(
+    with title: String = "카테고리",
+    image: UIImage = UIImage()
+  ) -> UICollectionViewCell {
+    categoryImageView.image = image
+    categoryTitle.text = title
+    return self
+  }
+  
+  func deselectedAnimation() {
+    UIView.animate(withDuration: 0.3) {
+      self.categoryImageView.transform = CGAffineTransform(scaleX: 0.95, y: 0.95)
+    }
+  }
+  
+  func selectedAnimation() {
+    UIView.animate(withDuration: 0.3) {
+      self.categoryImageView.transform = CGAffineTransform(scaleX: 1.2, y: 1.2)
+    }
+  }
+}
+
+// MARK: - LayoutSupport
+extension CategoryViewCell: LayoutSupport {
+  func addSubviews() {
+    _=[categoryImageView, categoryTitle]
+      .map { contentView.addSubview($0) }
+  }
+  
+  func setConstraints() {
+    _=[categoryImageViewConstraint, categoryTitleConstraint]
+      .map { NSLayoutConstraint.activate($0) }
+  }
+}
+
+// MARK: - Subviews constraint
+fileprivate extension CategoryViewCell {
+  var categoryImageViewConstraint: [NSLayoutConstraint] {
+    [categoryImageView.topAnchor.constraint(
+      equalTo: contentView.topAnchor,
+      constant: CategoryViewCellConstant.ImageView.spacingTop),
+     categoryImageView.leadingAnchor.constraint(
+      equalTo: contentView.leadingAnchor,
+      constant: CategoryViewCellConstant.ImageView.spacingLeft),
+     categoryImageView.trailingAnchor.constraint(
+      equalTo: contentView.trailingAnchor,
+      constant: -CategoryViewCellConstant.ImageView.spacingLeft),
+     categoryImageView.heightAnchor.constraint(
+      equalToConstant: CategoryViewCellConstant.ImageView.size.height)]
+  }
+  
+  var categoryTitleConstraint: [NSLayoutConstraint] {
+    [categoryTitle.topAnchor.constraint(
+      equalTo: categoryImageView.bottomAnchor,
+      constant: CategoryViewCellConstant.Title.spacingTop),
+     categoryTitle.leadingAnchor.constraint(
+      equalTo: contentView.leadingAnchor),
+     categoryTitle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+     categoryTitle.bottomAnchor.constraint(
+      equalTo: contentView.bottomAnchor,
+      constant: CategoryViewCellConstant.Title.spacingBottom)]
+  }
+}

--- a/travelPlan/Source/Feature/Feed/ViewController/FeedViewController.swift
+++ b/travelPlan/Source/Feature/Feed/ViewController/FeedViewController.swift
@@ -8,22 +8,36 @@
 import UIKit
 
 class FeedViewController: UIViewController {
+  // MARK: - Properties
+  let categoryPageView = CategoryPageView()
   
+  // MARK: - Lifecycle
   override func viewDidLoad() {
     super.viewDidLoad()
-    
-    // Do any additional setup after loading the view.
-    view.backgroundColor = .green.withAlphaComponent(0.15)
+    setupUI()
+  }
+}
+
+// MARK: - LayoutSupport
+extension FeedViewController: LayoutSupport {
+  func addSubviews() {
+    view.addSubview(categoryPageView)
   }
   
-  /*
-   // MARK: - Navigation
-   
-   // In a storyboard-based application, you will often want to do a little preparation before navigation
-   override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-   // Get the new view controller using segue.destination.
-   // Pass the selected object to the new view controller.
-   }
-   */
-  
+  func setConstraints() {
+    NSLayoutConstraint.activate(categoryPageViewConstraint)
+  }
+}
+
+fileprivate extension FeedViewController {
+  var categoryPageViewConstraint: [NSLayoutConstraint] {
+    [categoryPageView.topAnchor.constraint(
+      equalTo: view.safeAreaLayoutGuide.topAnchor),
+     categoryPageView.leadingAnchor.constraint(
+      equalTo: view.leadingAnchor),
+     categoryPageView.trailingAnchor.constraint(
+      equalTo: view.trailingAnchor),
+     categoryPageView.bottomAnchor.constraint(
+      equalTo: view.safeAreaLayoutGuide.bottomAnchor)]
+  }
 }

--- a/travelPlan/Source/Feature/Feed/ViewModel/CategoryPageViewModel.swift
+++ b/travelPlan/Source/Feature/Feed/ViewModel/CategoryPageViewModel.swift
@@ -1,0 +1,87 @@
+//
+//  CategoryPageViewModel.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/05/09.
+//
+
+import UIKit
+
+struct CategoryPageViewModel {
+  // MARK: - Properties
+  let data = categoryData
+}
+
+// MARK: - Helpers
+extension CategoryPageViewModel {
+  /// Return categoryView cell's title font size
+  /// - Parameter index: 특정 cell의 indexPath
+  /// - Returns: 특정 cell의 sizeToFit된 width 길이
+  func titleFontSize(
+    of index: IndexPath = IndexPath(row: 0, section: 0)
+  ) -> CGFloat {
+    let lb = UILabel()
+    lb.text = data[index.row]
+    lb.font = UIFont.systemFont(
+      ofSize: CategoryViewCellConstant.Title.fontSize)
+    lb.sizeToFit()
+    return lb.bounds.width
+  }
+  
+  /// Return scrollBar specific position's leading spacing
+  /// - Parameter titleWidth: 특정 categoryViewCell의 title 실제 길이
+  /// - Returns: cell에서 title을 제외한 영역중 절반 leading spacing
+  func scrollBarLeadingSpacing(_ titleWidth: CGFloat) -> CGFloat {
+    return (
+      CategoryViewConstant
+        .shared
+        .intrinsicContentSize
+        .width - titleWidth)/2.0
+  }
+  
+  func configCell(
+    _ collectionView: UICollectionView,
+    cellForItemAt indexPath: IndexPath,
+    type: CategoryViewType
+  ) -> UICollectionViewCell {
+    switch type {
+    case .categoryDetail:
+      return setupCategoryDetailCell(
+        collectionView,
+        cellForItemAt: indexPath)
+    default:
+      return setupCategoryCell(
+        collectionView,
+        cellForItemAt: indexPath)
+    }
+  }
+}
+
+// MARK: - Fileprivate helpers
+fileprivate extension CategoryPageViewModel {
+  func setupCategoryCell(
+    _ cv: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = cv.dequeueReusableCell(
+      withReuseIdentifier: CategoryViewCell.id,
+      for: indexPath
+    ) as? CategoryViewCell else {
+      return UICollectionViewCell()
+    }
+    return cell.configUI(with: data[indexPath.row])
+  }
+  
+  func setupCategoryDetailCell(
+    _ cv: UICollectionView,
+    cellForItemAt indexPath: IndexPath
+  ) -> UICollectionViewCell {
+    guard let cell = cv.dequeueReusableCell(
+      withReuseIdentifier: CategoryDetailViewCell.id,
+      for: indexPath
+    ) as? CategoryDetailViewCell else {
+      return UICollectionViewCell()
+    }
+    return cell.configCell(with: indexPath)
+  }
+}

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -22,6 +22,14 @@
 		1594F53B29FD517F00A58F20 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53A29FD517F00A58F20 /* Assets.xcassets */; };
 		1594F53E29FD517F00A58F20 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53C29FD517F00A58F20 /* LaunchScreen.storyboard */; };
 		15EF8C052A0829FD0068C744 /* LocationSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C042A0829FD0068C744 /* LocationSearchViewController.swift */; };
+		15EF8C972A0A18960068C744 /* CategoryPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C962A0A18960068C744 /* CategoryPageViewModel.swift */; };
+		15EF8C9B2A0A19100068C744 /* CategoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C9A2A0A19100068C744 /* CategoryView.swift */; };
+		15EF8C9D2A0A19190068C744 /* CategoryViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C9C2A0A19190068C744 /* CategoryViewCell.swift */; };
+		15EF8C9F2A0A19310068C744 /* CategoryDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C9E2A0A19310068C744 /* CategoryDetailView.swift */; };
+		15EF8CA12A0A19380068C744 /* CategoryDetailViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8CA02A0A19380068C744 /* CategoryDetailViewCell.swift */; };
+		15EF8CA32A0A197C0068C744 /* CategoryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8CA22A0A197C0068C744 /* CategoryPageView.swift */; };
+		15EF8CA62A0A19990068C744 /* CategoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8CA52A0A19990068C744 /* CategoryModel.swift */; };
+		15EF8CA92A0A19AF0068C744 /* CategoryConstant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8CA82A0A19AF0068C744 /* CategoryConstant.swift */; };
 		15F0A3F529FD58280049AB33 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 15F0A3F429FD58280049AB33 /* .swiftlint.yml */; };
 		15FEB5E52A050A99000A5F33 /* UIControl+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FEB5DA2A050A99000A5F33 /* UIControl+Combine.swift */; };
 		15FEB5E62A050A99000A5F33 /* UISwitch+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15FEB5DB2A050A99000A5F33 /* UISwitch+Combine.swift */; };
@@ -72,6 +80,14 @@
 		1594F53D29FD517F00A58F20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1594F53F29FD517F00A58F20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		15EF8C042A0829FD0068C744 /* LocationSearchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationSearchViewController.swift; sourceTree = "<group>"; };
+		15EF8C962A0A18960068C744 /* CategoryPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPageViewModel.swift; sourceTree = "<group>"; };
+		15EF8C9A2A0A19100068C744 /* CategoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryView.swift; sourceTree = "<group>"; };
+		15EF8C9C2A0A19190068C744 /* CategoryViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryViewCell.swift; sourceTree = "<group>"; };
+		15EF8C9E2A0A19310068C744 /* CategoryDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailView.swift; sourceTree = "<group>"; };
+		15EF8CA02A0A19380068C744 /* CategoryDetailViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryDetailViewCell.swift; sourceTree = "<group>"; };
+		15EF8CA22A0A197C0068C744 /* CategoryPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryPageView.swift; sourceTree = "<group>"; };
+		15EF8CA52A0A19990068C744 /* CategoryModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryModel.swift; sourceTree = "<group>"; };
+		15EF8CA82A0A19AF0068C744 /* CategoryConstant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CategoryConstant.swift; sourceTree = "<group>"; };
 		15F0A3F429FD58280049AB33 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		15FEB5DA2A050A99000A5F33 /* UIControl+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+Combine.swift"; sourceTree = "<group>"; };
 		15FEB5DB2A050A99000A5F33 /* UISwitch+Combine.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UISwitch+Combine.swift"; sourceTree = "<group>"; };
@@ -216,6 +232,10 @@
 		15BED2FB2A08236300F86321 /* Feed */ = {
 			isa = PBXGroup;
 			children = (
+				15EF8CA72A0A19A80068C744 /* Constant */,
+				15EF8CA42A0A198B0068C744 /* Model */,
+				15EF8C952A0A18880068C744 /* ViewModel */,
+				15EF8C932A0A185D0068C744 /* View */,
 				15BED2FC2A08249300F86321 /* ViewController */,
 			);
 			path = Feed;
@@ -308,6 +328,66 @@
 				15EF8C042A0829FD0068C744 /* LocationSearchViewController.swift */,
 			);
 			path = ViewController;
+			sourceTree = "<group>";
+		};
+		15EF8C932A0A185D0068C744 /* View */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8C942A0A18660068C744 /* CategoryPageView */,
+			);
+			path = View;
+			sourceTree = "<group>";
+		};
+		15EF8C942A0A18660068C744 /* CategoryPageView */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8CA22A0A197C0068C744 /* CategoryPageView.swift */,
+				15EF8C992A0A18FF0068C744 /* CategoryDetailView */,
+				15EF8C982A0A18F70068C744 /* CategoryView */,
+			);
+			path = CategoryPageView;
+			sourceTree = "<group>";
+		};
+		15EF8C952A0A18880068C744 /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8C962A0A18960068C744 /* CategoryPageViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		15EF8C982A0A18F70068C744 /* CategoryView */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8C9C2A0A19190068C744 /* CategoryViewCell.swift */,
+				15EF8C9A2A0A19100068C744 /* CategoryView.swift */,
+			);
+			path = CategoryView;
+			sourceTree = "<group>";
+		};
+		15EF8C992A0A18FF0068C744 /* CategoryDetailView */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8C9E2A0A19310068C744 /* CategoryDetailView.swift */,
+				15EF8CA02A0A19380068C744 /* CategoryDetailViewCell.swift */,
+			);
+			path = CategoryDetailView;
+			sourceTree = "<group>";
+		};
+		15EF8CA42A0A198B0068C744 /* Model */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8CA52A0A19990068C744 /* CategoryModel.swift */,
+			);
+			path = Model;
+			sourceTree = "<group>";
+		};
+		15EF8CA72A0A19A80068C744 /* Constant */ = {
+			isa = PBXGroup;
+			children = (
+				15EF8CA82A0A19AF0068C744 /* CategoryConstant.swift */,
+			);
+			path = Constant;
 			sourceTree = "<group>";
 		};
 		15FEB5D82A050A99000A5F33 /* Common */ = {
@@ -578,23 +658,31 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				15EF8C9D2A0A19190068C744 /* CategoryViewCell.swift in Sources */,
 				13254FE72A05158E00094218 /* SearchViewController.swift in Sources */,
 				15FEB5EC2A050A99000A5F33 /* ViewModelProtocols.swift in Sources */,
 				15FEB5E72A050A99000A5F33 /* UIButton+Combine.swift in Sources */,
 				15FEB5EB2A050A99000A5F33 /* ConvenienceInit.swift in Sources */,
 				15FEB5E92A050A99000A5F33 /* UITextField+Combine.swift in Sources */,
+				15EF8C972A0A18960068C744 /* CategoryPageViewModel.swift in Sources */,
 				13254FED2A0515D800094218 /* ProfileViewController.swift in Sources */,
 				15FEB5E62A050A99000A5F33 /* UISwitch+Combine.swift in Sources */,
+				15EF8C9B2A0A19100068C744 /* CategoryView.swift in Sources */,
 				15FEB5ED2A050A99000A5F33 /* LayoutSupport.swift in Sources */,
+				15EF8CA92A0A19AF0068C744 /* CategoryConstant.swift in Sources */,
 				15EF8C052A0829FD0068C744 /* LocationSearchViewController.swift in Sources */,
 				13254FE32A05147200094218 /* MainTabBarController.swift in Sources */,
+				15EF8CA62A0A19990068C744 /* CategoryModel.swift in Sources */,
 				15FEB5E82A050A99000A5F33 /* UIControl+CombineInteraction.swift in Sources */,
+				15EF8C9F2A0A19310068C744 /* CategoryDetailView.swift in Sources */,
 				13254FF02A0549D200094218 /* TabBarCase.swift in Sources */,
 				13254FEB2A0515C700094218 /* FavoriteViewController.swift in Sources */,
 				1594F53229FD517E00A58F20 /* AppDelegate.swift in Sources */,
 				15FEB5E52A050A99000A5F33 /* UIControl+Combine.swift in Sources */,
+				15EF8CA12A0A19380068C744 /* CategoryDetailViewCell.swift in Sources */,
 				1594F53429FD517E00A58F20 /* SceneDelegate.swift in Sources */,
 				13254FE92A0515A900094218 /* PlanViewController.swift in Sources */,
+				15EF8CA32A0A197C0068C744 /* CategoryPageView.swift in Sources */,
 				13254FE52A05157900094218 /* FeedViewController.swift in Sources */,
 				15FEB5EA2A050A99000A5F33 /* UIColor+.swift in Sources */,
 			);


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- FeedViewContrller의 category page view 추가

## ✨ [작업 내용]

- FeedViewController에서 사용 될 상단 category를 추가했습니다. 각각의 카테고리 항목마다 보여질 page도 구현했습니다.
- 기능을 최소한으로 분리해서 다른 뷰에서도 재사용할 수 있도록 리펙터링을 하려 했었는데.. CategoryView, CategoryDetailView 모두 보여지려면 내부 컴포넌트들이 spacing을 갖고 있어야 해서.. 분리할 수 없었습니다.
- category가 전환될 때 아주 약간 애니메이션을 추가했습니다.

categoryView의 컬랙션 뷰 높이가 지정된 이후에 categoryPageView에서  layoutSubviews()로 나머지 컬랙션 뷰인 categoryDetailView의 위치를 오토레이아웃으로 지정이 가능했습니다. 

## 📸  [스크린샷(선택)]

<img src="https://github.com/IF-TG/iOS/assets/96910404/a741386a-7a87-4861-8b06-2de19c417a94"  width="200" height="400"/>

## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

- layoutSubviews() 함수 덕분에 categoryView의 레이아웃이 세팅된 이후의 호출이 가능했고 categoryView의 레이아웃 세팅 -> categoryDetailView 레이아웃 cell item size 정리가 가능했습니다.
