### PR TITLE
Fix/feed post cell layout issue

### DIFF
--- a/travelPlan/Source/Feature/Feed/Mock/MockPostModel.swift
+++ b/travelPlan/Source/Feature/Feed/Mock/MockPostModel.swift
@@ -35,11 +35,11 @@ private extension MockPostModel {
   }
   
   func compressThumbImg(_ index: Int) -> UIImage {
-    return UIImage(named: tempThumb(index))!.compressJPEGImage(with: 0.003)!
+    return UIImage(named: tempThumb(index))!.compressJPEGImage(with: 0.0005)!
   }
   
   func compressProfImg(_ index: Int) -> UIImage {
-    return UIImage(named: tempProf(index))!.compressJPEGImage(with: 0.005)!
+    return UIImage(named: tempProf(index))!.compressJPEGImage(with: 0.0003)!
   }
   
   func initMockHeader() -> [PostHeaderModel] {

--- a/travelPlan/Source/Feature/Feed/View/PostView/PostCell/PostHeaderView/PostHeaderSubInfoView.swift
+++ b/travelPlan/Source/Feature/Feed/View/PostView/PostCell/PostHeaderView/PostHeaderSubInfoView.swift
@@ -51,6 +51,7 @@ class PostHeaderSubInfoView: UIView {
     super.init(frame: .zero)
     translatesAutoresizingMaskIntoConstraints = false
     setupUI()
+    setSubviewsLayoutPriorities()
   }
   
   required init?(coder: NSCoder) {
@@ -83,6 +84,16 @@ extension PostHeaderSubInfoView {
   
   private func setYearMonthDayRangeLabel(with text: String) {
     yearMonthDayRangeLabel.text = text
+  }
+  
+  private func setSubviewsLayoutPriorities() {
+    userNameLabel.setContentHuggingPriority(
+      UILayoutPriority(252), for: .horizontal)
+    userNameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    durationLabel.setContentCompressionResistancePriority(
+      UILayoutPriority(998), for: .horizontal)
+    yearMonthDayRangeLabel.setContentCompressionResistancePriority(
+      UILayoutPriority(999), for: .horizontal)
   }
 }
 
@@ -119,20 +130,18 @@ extension PostHeaderSubInfoView: LayoutSupport {
 // MARK: - LayoutSupport constraints
 private extension PostHeaderSubInfoView {
   var userNameLabelConstraints: [NSLayoutConstraint] {
-    [userNameLabel.leadingAnchor.constraint(
-      equalTo: leadingAnchor),
-     userNameLabel.topAnchor.constraint(
-      equalTo: topAnchor),
-     userNameLabel.bottomAnchor.constraint(
-      equalTo: bottomAnchor),
-     userNameLabel.widthAnchor.constraint(lessThanOrEqualToConstant: Constant.UserName.width)]
+    return [
+      userNameLabel.leadingAnchor.constraint(
+        equalTo: leadingAnchor),
+      userNameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
+      userNameLabel.widthAnchor.constraint(lessThanOrEqualToConstant: Constant.UserName.width),
+      userNameLabel.widthAnchor.constraint(greaterThanOrEqualToConstant: 0)]
   }
   
   var dividerView1Constraints: [NSLayoutConstraint] {
     let divider = dividerView.first!
     return [
-      divider.topAnchor.constraint(equalTo: topAnchor),
-      divider.bottomAnchor.constraint(equalTo: bottomAnchor),
+      divider.centerYAnchor.constraint(equalTo: centerYAnchor),
       divider.widthAnchor.constraint(
         equalToConstant: Constant.Divider.width),
       divider.heightAnchor.constraint(
@@ -143,21 +152,20 @@ private extension PostHeaderSubInfoView {
   }
   
   var durationLabelConstraints: [NSLayoutConstraint] {
-    [durationLabel.topAnchor.constraint(equalTo: topAnchor),
-     durationLabel.leadingAnchor.constraint(
-      equalTo: dividerView[0].trailingAnchor,
-      constant: Constant.Duration.Spacing.leading),
-     durationLabel.bottomAnchor.constraint(equalTo: bottomAnchor),
-     durationLabel.widthAnchor.constraint(
-      lessThanOrEqualToConstant: Constant.Duration.width)]
+    return [
+      durationLabel.centerYAnchor.constraint(
+        equalTo: centerYAnchor),
+      durationLabel.leadingAnchor.constraint(
+        equalTo: dividerView[0].trailingAnchor,
+        constant: Constant.Duration.Spacing.leading),
+      durationLabel.widthAnchor.constraint(
+        lessThanOrEqualToConstant: Constant.Duration.width)]
   }
   
   var dividerView2Constraints: [NSLayoutConstraint] {
     let divider = dividerView.last!
     return [
-      divider.topAnchor.constraint(
-        equalTo: topAnchor),
-      divider.bottomAnchor.constraint(equalTo: bottomAnchor),
+      divider.centerYAnchor.constraint(equalTo: centerYAnchor),
       divider.widthAnchor.constraint(
         equalToConstant: Constant.Divider.width),
       divider.heightAnchor.constraint(
@@ -168,12 +176,12 @@ private extension PostHeaderSubInfoView {
   }
   
   var dateRangeLabelConstraints: [NSLayoutConstraint] {
-    [yearMonthDayRangeLabel.topAnchor.constraint(equalTo: topAnchor),
+    [yearMonthDayRangeLabel.centerYAnchor.constraint(
+      equalTo: centerYAnchor),
      yearMonthDayRangeLabel.leadingAnchor.constraint(
       equalTo: dividerView[1].trailingAnchor,
       constant: Constant.DateRange.Spacing.leading),
-     yearMonthDayRangeLabel.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
-     yearMonthDayRangeLabel.bottomAnchor.constraint(equalTo: bottomAnchor)
-    ]
+     yearMonthDayRangeLabel.trailingAnchor.constraint(
+      lessThanOrEqualTo: trailingAnchor)]
   }
 }


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

closed #15 

postCell의 PostHeaderSubInfoView 의 subviews의 width, height ambiguous layout issue 수정

## ✨ [작업 내용]

기본적으로 width 1인 선을 나타내는 divider의 경우는 문제가 없었지만, UILabel의 텍스트가 지정된 widthAnchor.constarint(lessThanOrEqualTo:)의 크기를 넘어선 instrinsic content size일 때 문제가 발생되었습니다. 

이를 해결하기 위해 말씀해주신 content의 hugging, compression의 priority 제약조건을 다르게 추가했습니다. userNameLabel 경우 지정된 minimum width를 넘지 않도록 content hugging priority를 제일 높게 해주었고, 이 경우 yearMonthDayRangeLabel는 CompressionResistance priority 제일 높게 했습니다. durationLabel 또한 compression을 yearMonthDayRangeLabel 다음으로 높게 지정함으로 layout issue를 해결했습니다.

## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

<a href="https://sachithrasiriwardhane.medium.com/content-hugging-priority-and-compression-resistance-in-ios-fa0193f1a537">Content hugging priority and comression</a>
