### PR TITLE
Feature/feed userpostsearch

### DIFF
--- a/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
+++ b/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
@@ -19,34 +19,47 @@ extension UIColor {
   /// view.backgroundColor = UIColor.yg.gray0
   /// ```
   enum YG {
-    // Gray
+    // MARK: - Gray
+    /// #F9F9F9
     static let gray00Background = UIColor(
-      red: 0.975, green: 0.975, blue: 0.975, alpha: 1) // #F9F9F9
+      red: 0.975, green: 0.975, blue: 0.975, alpha: 1)
+    /// #F2F0F0
     static let veryLightGray = UIColor(
-      red: 0.949, green: 0.941, blue: 0.941, alpha: 1) // #F2F0F0
+      red: 0.949, green: 0.941, blue: 0.941, alpha: 1)
+    /// #D9D9D9
     static let gray0 = UIColor(
-      red: 0.851, green: 0.851, blue: 0.851, alpha: 1) // #D9D9D9
+      red: 0.851, green: 0.851, blue: 0.851, alpha: 1)
+    /// #C9C9C9
     static let gray1 = UIColor(
-      red: 0.788, green: 0.788, blue: 0.788, alpha: 1) // #C9C9C9
+      red: 0.788, green: 0.788, blue: 0.788, alpha: 1)
+    /// #B4B4B4
     static let gray2 = UIColor(
-      red: 0.704, green: 0.704, blue: 0.704, alpha: 1) // #B4B4B4
+      red: 0.704, green: 0.704, blue: 0.704, alpha: 1)
+    /// #717171
     static let gray3 = UIColor(
-      red: 0.443, green: 0.443, blue: 0.443, alpha: 1) // #717171
+      red: 0.443, green: 0.443, blue: 0.443, alpha: 1)
+    /// #676767
     static let gray4 = UIColor(
-      red: 0.404, green: 0.404, blue: 0.404, alpha: 1) // #676767
+      red: 0.404, green: 0.404, blue: 0.404, alpha: 1)
+    /// #484848
     static let gray5 = UIColor(
-      red: 0.283, green: 0.283, blue: 0.283, alpha: 1) // #484848
+      red: 0.283, green: 0.283, blue: 0.283, alpha: 1)
+    /// #4B4B4B
     static let gray6 = UIColor(
-      red: 0.294, green: 0.294, blue: 0.294, alpha: 1) // #4B4B4B
+      red: 0.294, green: 0.294, blue: 0.294, alpha: 1)
+    /// #333333
     static let gray7 = UIColor(
-      red: 0.2, green: 0.2, blue: 0.2, alpha: 1) // #333333
-
-    // brand color
+      red: 0.2, green: 0.2, blue: 0.2, alpha: 1)
+    
+    // MARK: -  brand color
+    /// #1BA0EB
     static let primary = UIColor(
-      red: 0.106, green: 0.627, blue: 0.922, alpha: 1) // #1BA0EB
+      red: 0.106, green: 0.627, blue: 0.922, alpha: 1)
+    /// #FE0135
     static let red = UIColor(
-      red: 0.996, green: 0.004, blue: 0.208, alpha: 1) // #FE0135
+      red: 0.996, green: 0.004, blue: 0.208, alpha: 1)
+    /// #EE0031
     static let red2 = UIColor(
-      red: 0.933, green: 0, blue: 0.192, alpha: 1) // #EE0031
+      red: 0.933, green: 0, blue: 0.192, alpha: 1)
   }
 }

--- a/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
+++ b/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
@@ -51,7 +51,7 @@ extension UIColor {
     static let gray7 = UIColor(
       red: 0.2, green: 0.2, blue: 0.2, alpha: 1)
     
-    // MARK: -  brand color
+    // MARK: - brand color
     /// #1BA0EB
     static let primary = UIColor(
       red: 0.106, green: 0.627, blue: 0.922, alpha: 1)

--- a/travelPlan/Source/Feature/Feed/View/Search/LeftAlignedCollectionViewFlowLayout.swift
+++ b/travelPlan/Source/Feature/Feed/View/Search/LeftAlignedCollectionViewFlowLayout.swift
@@ -25,23 +25,23 @@ class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
     var maxY: CGFloat = -1.0
     let edgeInset: CGFloat = 20
     
-    // copy 객체 customizing 후, return
+    // 원본 객체가 아닌, copy 객체 사용
     let copyAttributes = attributes.map {
-      if let copyAttribute = $0.copy() as? UICollectionViewLayoutAttributes {
-        return copyAttribute
-      }
-      return UICollectionViewLayoutAttributes()
+      guard let copyAttribute = $0.copy() as? UICollectionViewLayoutAttributes
+      else { return UICollectionViewLayoutAttributes() }
+      
+      return copyAttribute
     }
     
-    copyAttributes.forEach { layoutAttribute in
-      if layoutAttribute.representedElementCategory == .cell {
-        
+    copyAttributes
+      .filter { $0.representedElementCategory == .cell }
+      .forEach { layoutAttribute in
         guard let collectionView = self.collectionView else { return }
-        
+
         if layoutAttribute.frame.width >= collectionView.frame.width - (edgeInset * 2) {
           layoutAttribute.frame.size.width = collectionView.frame.width - (edgeInset * 2)
         }
-        
+
         if layoutAttribute.frame.origin.y >= maxY {
           leftMargin = self.sectionInset.left
         }
@@ -49,9 +49,8 @@ class LeftAlignedCollectionViewFlowLayout: UICollectionViewFlowLayout {
         layoutAttribute.frame.origin.x = leftMargin
         leftMargin += layoutAttribute.frame.width + self.minimumInteritemSpacing
         maxY = max(layoutAttribute.frame.maxY, maxY)
-      }
     }
-    
+
     return copyAttributes
   }
 }

--- a/travelPlan/Source/Feature/Feed/View/Search/RecommendationSearchFooterView.swift
+++ b/travelPlan/Source/Feature/Feed/View/Search/RecommendationSearchFooterView.swift
@@ -29,11 +29,11 @@ class RecommendationSearchFooterView: UICollectionReusableView {
 // MARK: - LayoutSupport
 extension RecommendationSearchFooterView: LayoutSupport {
   func addSubviews() {
-    self.addSubview(underLineView)
+    self.addSubview(self.underLineView)
   }
   
   func setConstraints() {
-    underLineView.setConstraint(
+    self.underLineView.setConstraint(
       fromSuperView: self,
       spacing: .init(leading: 20, trailing: 20, bottom: 10, top: 10)
     )

--- a/travelPlan/Source/Feature/Feed/View/Search/SearchTagCell.swift
+++ b/travelPlan/Source/Feature/Feed/View/Search/SearchTagCell.swift
@@ -52,7 +52,7 @@ extension SearchTagCell {
     self.deleteButton = UIButton()
     guard let deleteButton = self.deleteButton else { return UIButton() }
     deleteButton.setImage(UIImage(systemName: "xmark"), for: .normal)
-    deleteButton.tintColor = UIColor(hex: "#484848")
+    deleteButton.tintColor = .yg.gray5
     deleteButton.addTarget(self, action: #selector(didTapDeleteButton), for: .touchUpInside)
     return deleteButton
   }
@@ -61,7 +61,7 @@ extension SearchTagCell {
 // MARK: - Public Helpers
 extension SearchTagCell {
   func configure(_ text: String) {
-    tagLabel.text = text
+    self.tagLabel.text = text
   }
   
   func initSectionType(with sectionType: SectionType) {
@@ -78,7 +78,7 @@ extension SearchTagCell {
 extension SearchTagCell {
   @objc private func didTapDeleteButton(_ button: UIButton) {
     // DeleteCellTODO: 선택된 최근 검색 cell 삭제
-    delegate?.didTapDeleteButton(
+    self.delegate?.didTapDeleteButton(
       item: button.tag,
       in: sectionType?.rawValue ?? SectionType.recent.rawValue
     )
@@ -94,7 +94,7 @@ extension SearchTagCell: LayoutSupport {
       let deleteButton = makeDeleteButton()
       self.contentView.addSubview(deleteButton)
       fallthrough
-    case .recommendation: self.contentView.addSubview(tagLabel)
+    case .recommendation: self.contentView.addSubview(self.tagLabel)
     case .none: break
     }
   }
@@ -102,23 +102,23 @@ extension SearchTagCell: LayoutSupport {
   func setConstraints() {
     switch self.sectionType {
     case .recommendation:
-      tagLabel.snp.makeConstraints {
+      self.tagLabel.snp.makeConstraints {
         $0.leading.equalToSuperview().inset(13)
         $0.trailing.equalToSuperview().inset(13)
         $0.centerY.equalToSuperview()
       }
     case .recent:
-      guard let deleteButton = deleteButton else { return }
+      guard let deleteButton = self.deleteButton else { return }
       
-      tagLabel.snp.makeConstraints {
+      self.tagLabel.snp.makeConstraints {
         $0.leading.equalToSuperview().inset(13)
         $0.centerY.equalToSuperview()
       }
       
       deleteButton.snp.makeConstraints {
-        $0.leading.equalTo(tagLabel.snp.trailing).offset(4)
+        $0.leading.equalTo(self.tagLabel.snp.trailing).offset(4)
         $0.trailing.equalToSuperview().inset(13)
-        $0.centerY.equalTo(tagLabel)
+        $0.centerY.equalTo(self.tagLabel)
         $0.size.equalTo(10)
       }
     case .none: break

--- a/travelPlan/Source/Feature/Feed/View/Search/UserPostSearchHeaderView.swift
+++ b/travelPlan/Source/Feature/Feed/View/Search/UserPostSearchHeaderView.swift
@@ -45,7 +45,7 @@ final class UserPostSearchHeaderView: UICollectionReusableView {
 // MARK: - Public Helpers
 extension UserPostSearchHeaderView {
   func prepare(title: String?) {
-    titleLabel.text = title
+    self.titleLabel.text = title
   }
   
   func initSectionType(with sectionType: SectionType) {
@@ -65,7 +65,7 @@ extension UserPostSearchHeaderView {
     guard let button = self.deleteAllButton else { return UIButton() }
     
     button.setTitle("전체 삭제", for: .normal)
-    button.setTitleColor(UIColor(hex: "676767"), for: .normal)
+    button.setTitleColor(.yg.gray4, for: .normal)
     button.titleLabel?.font = .systemFont(ofSize: 12, weight: .semibold)
     button.addTarget(self, action: #selector(didTapDeleteAllButton), for: .touchUpInside)
     return button
@@ -75,7 +75,7 @@ extension UserPostSearchHeaderView {
 // MARK: - Actions
 extension UserPostSearchHeaderView {
   @objc private func didTapDeleteAllButton(_ button: UIButton) {
-    delegate?.didTapDeleteAllButton()
+    self.delegate?.didTapDeleteAllButton()
   }
 }
 
@@ -89,7 +89,7 @@ extension UserPostSearchHeaderView: LayoutSupport {
       self.addSubview(deleteAllButton)
       fallthrough
     case .recommendation:
-      self.addSubview(titleLabel)
+      self.addSubview(self.titleLabel)
     case .none: break
     }
   }
@@ -97,7 +97,7 @@ extension UserPostSearchHeaderView: LayoutSupport {
   func setConstraints() {
     switch self.sectionType {
     case .recent:
-      guard let button = deleteAllButton else { return }
+      guard let button = self.deleteAllButton else { return }
       
       button.snp.makeConstraints {
         $0.centerY.equalToSuperview()
@@ -105,7 +105,7 @@ extension UserPostSearchHeaderView: LayoutSupport {
       }
       fallthrough
     case .recommendation:
-      titleLabel.snp.makeConstraints {
+      self.titleLabel.snp.makeConstraints {
         $0.centerY.equalToSuperview()
         $0.leading.equalToSuperview().inset(20)
       }

--- a/travelPlan/Source/Feature/Feed/ViewController/UserPostSearchViewController.swift
+++ b/travelPlan/Source/Feature/Feed/ViewController/UserPostSearchViewController.swift
@@ -217,7 +217,7 @@ extension UserPostSearchViewController {
   }
   
   @objc private func editingChangedTextField(_ textField: UITextField) {
-    _editingTextField.send(textField.text ?? "")
+    self._editingTextField.send(textField.text ?? "")
   }
   
   @objc private func dismissKeyboard() {

--- a/travelPlan/Source/Feature/Feed/ViewController/UserPostSearchViewController.swift
+++ b/travelPlan/Source/Feature/Feed/ViewController/UserPostSearchViewController.swift
@@ -14,9 +14,19 @@ final class UserPostSearchViewController: UIViewController {
   typealias State = UserPostSearchViewModel.UserPostSearchState
   
   // MARK: - Properties
-  let viewModel = UserPostSearchViewModel()
+  private let viewModel = UserPostSearchViewModel()
   
-  lazy var backButtonItem = UIBarButtonItem(
+  private lazy var searchBarButtonItem = UIBarButtonItem(
+    image: UIImage(named: "search")?.withRenderingMode(.alwaysTemplate),
+    style: .plain,
+    target: self,
+    action: #selector(didTapSearchButton)
+  ).set {
+    $0.isEnabled = true
+    $0.tintColor = .yg.gray1
+  }
+  
+  private lazy var backButtonItem = UIBarButtonItem(
     image: UIImage(named: "back")?.withRenderingMode(.alwaysOriginal),
     style: .plain,
     target: self,
@@ -29,6 +39,7 @@ final class UserPostSearchViewController: UIViewController {
     $0.font = .init(pretendard: .regular, size: 16)
     $0.autocorrectionType = .no
     $0.delegate = self
+    $0.addTarget(self, action: #selector(editingChangedTextField), for: .editingChanged)
   }
   
   private lazy var leftAlignedCollectionViewFlowLayout:
@@ -63,15 +74,15 @@ final class UserPostSearchViewController: UIViewController {
     )
   }
   
+  // Combine
   private var subscriptions = Set<AnyCancellable>()
-  private let _viewDidLoad = PassthroughSubject<Void, Never>()
   private let _didSelectedItem = PassthroughSubject<IndexPath, Never>()
   private let _didTapDeleteButton = PassthroughSubject<(Int, Int), Never>()
   private let _didTapDeleteAllButton = PassthroughSubject<Void, Never>()
   private let _didTapView = PassthroughSubject<Void, Never>()
   private let _didTapSearchTextField = PassthroughSubject<Void, Never>()
   private let _didTapSearchButton = PassthroughSubject<String, Never>()
-  private let _editingTextField = PassthroughSubject<Void, Never>()
+  private let _editingTextField = PassthroughSubject<String, Never>()
   private let _didTapEnterAlertAction = PassthroughSubject<Void, Never>()
   
   // MARK: - LifeCycle
@@ -84,11 +95,10 @@ final class UserPostSearchViewController: UIViewController {
   }
 }
 
-// MARK: - Helpers
+// MARK: - Bind
 extension UserPostSearchViewController {
   private func bind() {
     let input = Input(
-      viewDidLoad: _viewDidLoad.eraseToAnyPublisher(),
       didSelectedItem: _didSelectedItem.eraseToAnyPublisher(),
       didTapDeleteButton: _didTapDeleteButton.eraseToAnyPublisher(),
       didTapDeleteAllButton: _didTapDeleteAllButton.eraseToAnyPublisher(),
@@ -112,14 +122,12 @@ extension UserPostSearchViewController {
       } receiveValue: { [weak self] in
         self?.render($0)
       }
-      .store(in: &subscriptions)
+      .store(in: &self.subscriptions)
   }
   
   private func render(_ state: State) {
     switch state {
-    case .none: break
-    case .gotoBack:
-      print("DEBUG: UserPostSearchVC -> FeedVC")
+    case .gotoBack: print("DEBUG: UserPostSearchVC -> FeedVC")
     case .gotoSearch(let text):
       searchTextField.resignFirstResponder()
       print("DEBUG: UserPostSearchVC -> SearchResultVC, keyword:\(text)")
@@ -129,9 +137,21 @@ extension UserPostSearchViewController {
       collectionView.reloadSections(IndexSet(section...section))
     case .deleteAllCells(let section):
       collectionView.reloadSections(IndexSet(section...section))
+    case .changeButtonColor(let isChanged):
+      if isChanged {
+        self.searchBarButtonItem.tintColor = .yg.primary
+        self.searchBarButtonItem.isEnabled = true
+      } else {
+        self.searchBarButtonItem.tintColor = .yg.gray1
+        self.searchBarButtonItem.isEnabled = false
+      }
+    case .none: break
     }
   }
-  
+}
+
+// MARK: - Helpers
+extension UserPostSearchViewController {
   private func setupAlertController() {
     let message = "최근 검색 내역을\n모두 삭제하시겠습니까?"
     let attrMessageString = NSMutableAttributedString(string: message)
@@ -149,10 +169,8 @@ extension UserPostSearchViewController {
     alert.setValue(attrMessageString, forKey: "attributedTitle")
     
     let cancelAction = UIAlertAction(title: "취소", style: .cancel)
-    let enterAction = UIAlertAction(title: "확인", style: .default) { [weak self] _ in
-      
-      print("전체 삭제 logic")
-      self?._didTapEnterAlertAction.send()
+    let enterAction = UIAlertAction(title: "확인", style: .default) { _ in
+      self._didTapEnterAlertAction.send()
     }
     
     alert.addAction(cancelAction)
@@ -164,28 +182,15 @@ extension UserPostSearchViewController {
     let paddingBarButtonItem = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
     paddingBarButtonItem.width = 10
     
-    let textFieldButtonItem = UIBarButtonItem(customView: searchTextField)
+    let textFieldButtonItem = UIBarButtonItem(customView: self.searchTextField)
     var barButtonItems = [UIBarButtonItem]()
     
-    barButtonItems.append(backButtonItem)
+    barButtonItems.append(self.backButtonItem)
     barButtonItems.append(paddingBarButtonItem)
     barButtonItems.append(textFieldButtonItem)
     
     navigationItem.leftBarButtonItems = barButtonItems
-    
-    let searchBarButtonItem = UIBarButtonItem(
-      image: UIImage(named: "search")?.withRenderingMode(.alwaysOriginal),
-      style: .plain,
-      target: self,
-      action: #selector(didTapSearchButton)
-    )
-
-//    let searchButton = UIButton()
-//    searchButton.setImage(UIImage(named: "search")?.withRenderingMode(.alwaysOriginal), for: .normal)
-//    searchButton.addTarget(self, action: #selector(didTapSearchButton), for: .touchUpInside)
-//
-//    let searchBarButtonItem = UIBarButtonItem(customView: searchButton)
-    navigationItem.rightBarButtonItem = searchBarButtonItem
+    navigationItem.rightBarButtonItem = self.searchBarButtonItem
   }
 }
 
@@ -194,22 +199,26 @@ extension UserPostSearchViewController {
   
   // SearchButton은 textField에 text가 들어오면 파란색으로 color 바뀜
   @objc private func didTapSearchButton() {
-    _didTapSearchButton.send(searchTextField.text ?? "")
+    self._didTapSearchButton.send(self.searchTextField.text ?? "")
   }
   
   @objc private func didTapBackButton() {
-    navigationController?.popViewController(animated: true)
+    self.navigationController?.popViewController(animated: true)
+  }
+  
+  @objc private func editingChangedTextField(_ textField: UITextField) {
+    _editingTextField.send(textField.text ?? "")
   }
 }
 
 // MARK: - LayoutSupport
 extension UserPostSearchViewController: LayoutSupport {
   func addSubviews() {
-    self.view.addSubview(collectionView)
+    self.view.addSubview(self.collectionView)
   }
   
   func setConstraints() {
-    collectionView.snp.makeConstraints {
+    self.collectionView.snp.makeConstraints {
       $0.leading.trailing.equalTo(self.view.safeAreaLayoutGuide)
       $0.top.bottom.equalToSuperview()
     }
@@ -224,28 +233,28 @@ extension UserPostSearchViewController: UICollectionViewDelegateFlowLayout {
     layout collectionViewLayout: UICollectionViewLayout,
     sizeForItemAt indexPath: IndexPath
   ) -> CGSize {
-    return viewModel.sizeForItem(at: indexPath)
+    return self.viewModel.sizeForItem(at: indexPath)
   }
   
   func collectionView(
     _ collectionView: UICollectionView,
     didSelectItemAt indexPath: IndexPath
   ) {
-    _didSelectedItem.send(indexPath)
+    self._didSelectedItem.send(indexPath)
   }
 }
 
 // MARK: - UICollectionViewDataSource
 extension UserPostSearchViewController: UICollectionViewDataSource {
   func numberOfSections(in collectionView: UICollectionView) -> Int {
-    return viewModel.numberOfSections()
+    return self.viewModel.numberOfSections()
   }
   
   func collectionView(
     _ collectionView: UICollectionView,
     numberOfItemsInSection section: Int
   ) -> Int {
-    return viewModel.numberOfItemsInSection(section)
+    return self.viewModel.numberOfItemsInSection(section)
   }
   
   func collectionView(
@@ -278,7 +287,7 @@ extension UserPostSearchViewController: UICollectionViewDataSource {
       ) as? UserPostSearchHeaderView else { return UICollectionReusableView() }
       
       titleHeaderView.delegate = self
-      let titleString = viewModel.fetchHeaderTitle(titleHeaderView, at: indexPath.section)
+      let titleString = self.viewModel.fetchHeaderTitle(titleHeaderView, at: indexPath.section)
       titleHeaderView.prepare(title: titleString)
       
       return titleHeaderView
@@ -291,7 +300,7 @@ extension UserPostSearchViewController: UICollectionViewDataSource {
         for: indexPath
       ) as? RecommendationSearchFooterView else { return UICollectionReusableView() }
      
-      if viewModel.isRecentSection(at: indexPath.section) {
+      if self.viewModel.isRecentSection(at: indexPath.section) {
         lineFooterView.isHidden = true
       }
 
@@ -304,9 +313,7 @@ extension UserPostSearchViewController: UICollectionViewDataSource {
 // MARK: - UITextFieldDelegate
 extension UserPostSearchViewController: UITextFieldDelegate {
   func textFieldShouldReturn(_ textField: UITextField) -> Bool {
-    guard let searchText = textField.text else { return false }
-    
-    _didTapSearchButton.send(searchText)
+    self._didTapSearchButton.send(textField.text ?? "")
     return true
   }
 }
@@ -314,14 +321,16 @@ extension UserPostSearchViewController: UITextFieldDelegate {
 // MARK: - UserPostSearchHeaderViewDelegate
 extension UserPostSearchViewController: UserPostSearchHeaderViewDelegate {
   func didTapDeleteAllButton() {
-    _didTapDeleteAllButton.send()
+    self._didTapDeleteAllButton.send()
   }
 }
 
 // MARK: - SearchTagCellDelegate
 extension UserPostSearchViewController: SearchTagCellDelegate {
   func didTapDeleteButton(item: Int, in section: Int) {
-    print("삭제할 item: \(item), section: \(section)")
-    _didTapDeleteButton.send((item, section))
+    self._didTapDeleteButton.send((item, section))
   }
 }
+
+// KeyboardTODO: - CollectionView 클릭 시, keyboard 내리기
+// CellLayoutFIXME: - 최근 검색 키워드 충분히 길어진 경우, 잘못된 tag cell size

--- a/travelPlan/Source/Feature/Feed/ViewModel/UserPostSearchViewModel.swift
+++ b/travelPlan/Source/Feature/Feed/ViewModel/UserPostSearchViewModel.swift
@@ -84,7 +84,9 @@ extension UserPostSearchViewModel: ViewModelCase {
   private func didSelectedItemChain(_ input: Input) -> Output {
     return input.didSelectedItem
       .map { [weak self] indexPath -> State in
-          .gotoSearch(searchText: self?.model[indexPath.section].items[indexPath.item] ?? "")
+          .gotoSearch(
+            searchText: self?.model[indexPath.section].items[indexPath.item] ?? ""
+          )
       }.eraseToAnyPublisher()
   }
   
@@ -115,7 +117,7 @@ extension UserPostSearchViewModel: ViewModelCase {
 // MARK: - Helpers
 extension UserPostSearchViewModel {
   private func removeItemModel(item: Int, section: Int) {
-    model[section].items.remove(at: item)
+    self.model[section].items.remove(at: item)
   }
   
   private func isValueChanged(text: String) -> Bool {
@@ -132,7 +134,7 @@ extension UserPostSearchViewModel {
     let widthPadding: CGFloat = 13
     let heightPadding: CGFloat = 4
     
-    let text = model[indexPath.section].items[indexPath.item]
+    let text = self.model[indexPath.section].items[indexPath.item]
     let textSize = (text as NSString)
       .size(withAttributes: [.font: UIFont(pretendard: .medium, size: 14)!])
     
@@ -159,7 +161,10 @@ extension UserPostSearchViewModel {
     return SectionType.allCases.count
   }
   
-  func cellForItem(_ searchTagCell: SearchTagCell, at indexPath: IndexPath) -> String {
+  func cellForItem(
+    _ searchTagCell: SearchTagCell,
+    at indexPath: IndexPath
+  ) -> String {
     // 하나의 Cell class를 재사용해서 변형시키므로, section별로 Cell 구분화
     switch indexPath.section {
     case SearchSection.recommendation.rawValue:
@@ -170,14 +175,17 @@ extension UserPostSearchViewModel {
     }
     searchTagCell.deleteButton?.tag = indexPath.item
     
-    return model[indexPath.section].items[indexPath.item]
+    return self.model[indexPath.section].items[indexPath.item]
   }
   
   func numberOfItemsInSection(_ section: Int) -> Int {
-    return model[section].items.count
+    return self.model[section].items.count
   }
   
-  func fetchHeaderTitle(_ headerView: UserPostSearchHeaderView, at section: Int) -> String {
+  func fetchHeaderTitle(
+    _ headerView: UserPostSearchHeaderView,
+    at section: Int
+  ) -> String {
     switch section {
     case SearchSection.recommendation.rawValue:
       headerView.initSectionType(with: .recommendation)

--- a/travelPlan/Source/Feature/Feed/ViewModel/UserPostSearchViewModel.swift
+++ b/travelPlan/Source/Feature/Feed/ViewModel/UserPostSearchViewModel.swift
@@ -33,14 +33,13 @@ final class UserPostSearchViewModel {
 extension UserPostSearchViewModel {
   // MARK: - Input
   struct UserPostSearchEvent {
-    let viewDidLoad: AnyPublisher<Void, Never>
     let didSelectedItem: AnyPublisher<IndexPath, Never>
     let didTapDeleteButton: AnyPublisher<(Int, Int), Never>
     let didTapDeleteAllButton: AnyPublisher<Void, Never>
     let didTapView: AnyPublisher<Void, Never>
     let didTapSearchTextField: AnyPublisher<Void, Never>
     let didTapSearchButton: AnyPublisher<String, Never>
-    let editingTextField: AnyPublisher<Void, Never>
+    let editingTextField: AnyPublisher<String, Never>
     let didTapEnterAlertAction: AnyPublisher<Void, Never>
   }
   
@@ -52,53 +51,77 @@ extension UserPostSearchViewModel {
     case deleteCell(section: Int)
     case deleteAllCells(section: Int)
     case presentAlert
+    case changeButtonColor(Bool)
   }
 }
 
 // MARK: - ViewModelCase
 extension UserPostSearchViewModel: ViewModelCase {
   func transform(_ input: Input) -> Output {
-    let viewDidLoadChain = input.viewDidLoad
-      .receive(on: RunLoop.main)
-      .map { _ -> State in return .none }
+    return Publishers.MergeMany([
+      editingTextFieldChain(input),
+      didTapShearchButtonChain(input),
+      didSelectedItemChain(input),
+      didTapDeleteAllButtonChain(input),
+      didTapDeleteButtonChain(input),
+      didTapEnterAlertActionChain(input)
+    ]).eraseToAnyPublisher()
+  }
+  
+  private func editingTextFieldChain(_ input: Input) -> Output {
+    return input.editingTextField
+      .map { State.changeButtonColor(self.isValueChanged(text: $0)) }
       .eraseToAnyPublisher()
-    
-    let didTapShearchButtonChain = input.didTapSearchButton
+  }
+  
+  private func didTapShearchButtonChain(_ input: Input) -> Output {
+    return input.didTapSearchButton
       .map { searchText -> State in
-        print("\(searchText) 키워드로 검색 하겠음.")
         return .gotoSearch(searchText: searchText)
       }.eraseToAnyPublisher()
-    
-    let didSelectedItemChain = input.didSelectedItem
+  }
+  
+  private func didSelectedItemChain(_ input: Input) -> Output {
+    return input.didSelectedItem
       .map { [weak self] indexPath -> State in
           .gotoSearch(searchText: self?.model[indexPath.section].items[indexPath.item] ?? "")
       }.eraseToAnyPublisher()
-    
-    let didTapDeleteAllButtonChain = input.didTapDeleteAllButton
+  }
+  
+  private func didTapDeleteAllButtonChain(_ input: Input) -> Output {
+    return input.didTapDeleteAllButton
       .map { _ -> State in
         return .presentAlert
       }.eraseToAnyPublisher()
-    
-    let didTapDeleteButtonChain = input.didTapDeleteButton
+  }
+  
+  private func didTapDeleteButtonChain(_ input: Input) -> Output {
+    return input.didTapDeleteButton
       .map { [weak self] item, section -> State in
         self?.removeItemModel(item: item, section: section)
         return .deleteCell(section: section)
       }.eraseToAnyPublisher()
-    
-    let didTapEnterAlertActionChain = input.didTapEnterAlertAction
+  }
+  
+  private func didTapEnterAlertActionChain(_ input: Input) -> Output {
+    return input.didTapEnterAlertAction
       .map { [weak self] _ -> State in
         self?.model[SectionType.recent.rawValue].items.removeAll()
         return .deleteAllCells(section: SectionType.recent.rawValue)
       }.eraseToAnyPublisher()
-    
-    return Publishers.MergeMany([
-      viewDidLoadChain,
-      didTapShearchButtonChain,
-      didSelectedItemChain,
-      didTapDeleteAllButtonChain,
-      didTapDeleteButtonChain,
-      didTapEnterAlertActionChain
-    ]).eraseToAnyPublisher()
+  }
+}
+
+// MARK: - Helpers
+extension UserPostSearchViewModel {
+  private func removeItemModel(item: Int, section: Int) {
+    model[section].items.remove(at: item)
+  }
+  
+  private func isValueChanged(text: String) -> Bool {
+    if text.count > 0 {
+      return true
+    } else { return false }
   }
 }
 
@@ -118,7 +141,7 @@ extension UserPostSearchViewModel {
       return CGSize(
         width: textSize.width + (widthPadding * 2),
         height: textSize.height + (heightPadding * 2)
-        )
+      )
     case SectionType.recent.rawValue:
       let buttonWidth: CGFloat = 10
       let componentPadding: CGFloat = 4
@@ -168,9 +191,5 @@ extension UserPostSearchViewModel {
   
   func isRecentSection(at section: Int) -> Bool {
     return section == SectionType.recent.rawValue
-  }
-  
-  func removeItemModel(item: Int, section: Int) {
-    model[section].items.remove(at: item)
   }
 }


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]
- NavigationBar constraint issue 해결
- Search Button UI 추가
- 화면 터치 시, keyboard 내리기 구현

## ✨ [작업 내용]
#### issue No.1
- keyboard를 내리기 위해, UITapGestureRecognizer를 collectionView에 추가해주는 방법을 사용했습니다.
- collectionView cell을 selected할 때, didSelectedItemAt 함수가 호출되지 않는 issue 발생했습니다.

#### Solution
- tapGesture.cancelsTouchesInView = false 코드 추가
	- true인 경우: guesture recognizer가 gesture를 인식할 때, 보류 중인 제스처의 터치가 view로 전달되지 않고 이전에 전달된 터치는 취소 (default: true)
	- false인 경우: view는 멀티 터치 sequence에서 모든 터치를 수신
---
#### issue No.2
- 화면 터치시, keyboard를 내리는 코드를 작업하던 중 마주했던 issue입니다.
- 손에 익었던 코드인 view.navigationBar.endEditing(true)를 사용했는데, first responder가 사임되지 않는 issue 발생했습니다.

#### Solution
- textField는 UIViewController의 view에 놓여 있는 것이 아니라, UINavigationController의 navigationBar에 놓여있습니다.
-  navigationController?.navigationBar.endEditing(true)를 호출해서 문제를 해결했습니다.
