### PR TITLE
[Feature] base bottom sheet를 구현했습니다.

### DIFF
--- a/travelPlan/Source/Common/Extension/UIViewController.swift
+++ b/travelPlan/Source/Common/Extension/UIViewController.swift
@@ -1,0 +1,15 @@
+//
+//  UIViewController.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/09/15.
+//
+
+import UIKit
+
+extension UIViewController {
+  func presentBottomSheet(_ viewController: UIViewController) {
+    viewController.modalPresentationStyle = .overFullScreen
+    present(viewController, animated: false)
+  }
+}

--- a/travelPlan/Source/Common/View/BaseBottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BaseBottomSheetView.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class BaseBottomSheetView: UIView {
   enum Constants {
+    static let cornerRadius: CGFloat = 8
     enum TopView {
       static let height: CGFloat = 20
     }
@@ -26,6 +27,7 @@ class BaseBottomSheetView: UIView {
   // MARK: - Properties
   private let topView = UIView(frame: .zero).set {
     $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.backgroundColor = .white
   }
   
   private let topIndicatorView = UIView(frame: .zero).set {
@@ -54,6 +56,13 @@ class BaseBottomSheetView: UIView {
     translatesAutoresizingMaskIntoConstraints = false
   }
   
+  init(radius: CGFloat) {
+    super.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+    layer.cornerRadius = radius
+    configureUI()
+  }
+  
   // MARK: - Helper
   func setContentView(_ contentView: UIView) {
     self.contentView.addSubview(contentView)
@@ -65,9 +74,16 @@ class BaseBottomSheetView: UIView {
     layoutIfNeeded()
   }
   
+  func setCornerRadius(_ radius: CGFloat) {
+    layer.cornerRadius = Constants.cornerRadius
+  }
+  
   // MARK: - Private helper
   func configureUI() {
     setupUI()
+    layer.cornerRadius = Constants.cornerRadius
+    clipsToBounds = true
+    layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
   }
 }
 // MARK: - LayoutSupportable

--- a/travelPlan/Source/Common/View/BaseBottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BaseBottomSheetView.swift
@@ -1,0 +1,125 @@
+//
+//  BaseBottomSheetView.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/09/14.
+//
+
+import UIKit
+
+class BaseBottomSheetView: UIView {
+  enum Constants {
+    enum TopView {
+      static let height: CGFloat = 20
+    }
+    
+    enum TopIndicatorView {
+      static let height: CGFloat = 5
+      enum Inset {
+        static let top: CGFloat = 5
+        static let leading: CGFloat = 169
+        static let trailing = leading
+      }
+    }
+  }
+  
+  // MARK: - Properties
+  private let topView = UIView(frame: .zero).set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  private let topIndicatorView = UIView(frame: .zero).set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.backgroundColor = .YG.gray1
+    $0.layer.cornerRadius = Constants.TopIndicatorView.height/2
+  }
+  
+  private var contentView = UIView(frame: .zero).set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+  }
+  
+  // MARK: - Lifecycle
+  override init(frame: CGRect) {
+    super.init(frame: frame)
+    configureUI()
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    configureUI()
+  }
+  
+  // MARK: - Helper
+  func setContentView(_ contentView: UIView) {
+    self.contentView.addSubview(contentView)
+    NSLayoutConstraint.activate([
+      contentView.leadingAnchor.constraint(equalTo: self.contentView.leadingAnchor),
+      contentView.topAnchor.constraint(equalTo: self.contentView.topAnchor),
+      contentView.trailingAnchor.constraint(equalTo: self.contentView.trailingAnchor),
+      contentView.bottomAnchor.constraint(equalTo: self.contentView.bottomAnchor)])
+    layoutIfNeeded()
+  }
+  
+  // MARK: - Private helper
+  func configureUI() {
+    setupUI()
+  }
+}
+// MARK: - LayoutSupportable
+extension BaseBottomSheetView: LayoutSupport {
+  func addSubviews() {
+    _=[topView,
+       topIndicatorView,
+       contentView
+    ].map  {
+      addSubview($0)
+    }
+  }
+  
+  func setConstraints() {
+    _=[topViewConstraints,
+       topIndicatorViewConstraints,
+       contentViewConstraints
+    ].map {
+      NSLayoutConstraint.activate($0)
+    }
+  }
+}
+
+// MARK: - Layout supportable private helper
+private extension BaseBottomSheetView {
+  var topViewConstraints: [NSLayoutConstraint] {
+    typealias Const = Constants.TopView
+    return [
+      topView.leadingAnchor.constraint(
+        equalTo: leadingAnchor),
+      topView.trailingAnchor.constraint(
+        equalTo: trailingAnchor),
+      topView.topAnchor.constraint(
+        equalTo: topAnchor)]
+  }
+  
+  var topIndicatorViewConstraints: [NSLayoutConstraint] {
+    typealias Const = Constants.TopIndicatorView
+    typealias Inset = Const.Inset
+    return [
+      topIndicatorView.topAnchor.constraint(
+        equalTo: topView.topAnchor,
+        constant: Inset.top),
+      topIndicatorView.leadingAnchor.constraint(
+        equalTo: leadingAnchor,
+        constant: Inset.leading),
+      topIndicatorView.trailingAnchor.constraint(
+        equalTo: trailingAnchor,
+        constant: -Inset.trailing),
+      topIndicatorView.heightAnchor.constraint(equalToConstant: Const.height)]
+  }
+  
+  var contentViewConstraints: [NSLayoutConstraint] {
+    return [
+      contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+      contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+      contentView.topAnchor.constraint(equalTo: topView.bottomAnchor),
+      contentView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+  }
+}

--- a/travelPlan/Source/Common/View/BaseBottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BaseBottomSheetView.swift
@@ -49,6 +49,11 @@ class BaseBottomSheetView: UIView {
     configureUI()
   }
   
+  convenience init() {
+    self.init(frame: .zero)
+    translatesAutoresizingMaskIntoConstraints = false
+  }
+  
   // MARK: - Helper
   func setContentView(_ contentView: UIView) {
     self.contentView.addSubview(contentView)
@@ -71,7 +76,7 @@ extension BaseBottomSheetView: LayoutSupport {
     _=[topView,
        topIndicatorView,
        contentView
-    ].map  {
+    ].map {
       addSubview($0)
     }
   }

--- a/travelPlan/Source/Common/View/BottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BottomSheetView.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol BottomSheetViewDelegate: AnyObject {
+  func bottomSheetView(_ bottomSheetView: BottomSheetView, withPenGesture gesture: UIPanGestureRecognizer)
+}
+
 class BottomSheetView: UIView {
   enum Constants {
     static let cornerRadius: CGFloat = 8
@@ -39,6 +43,8 @@ class BottomSheetView: UIView {
   private var contentView = UIView(frame: .zero).set {
     $0.translatesAutoresizingMaskIntoConstraints = false
   }
+  
+  weak var delegate: BottomSheetViewDelegate?
   
   // MARK: - Lifecycle
   override init(frame: CGRect) {
@@ -96,7 +102,7 @@ class BottomSheetView: UIView {
   
   // MARK: - Action
   @objc func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
-    print("무야호")
+    delegate?.bottomSheetView(self, withPenGesture: gesture)
   }
 }
 // MARK: - LayoutSupportable

--- a/travelPlan/Source/Common/View/BottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BottomSheetView.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import Combine
 
 protocol BottomSheetViewDelegate: AnyObject {
   func bottomSheetView(_ bottomSheetView: BottomSheetView, withPenGesture gesture: UIPanGestureRecognizer)
@@ -45,23 +44,17 @@ class BottomSheetView: UIView {
     $0.translatesAutoresizingMaskIntoConstraints = false
   }
   
-  private let panGesturePublisher = PassthroughSubject<UIPanGestureRecognizer, Never>()
-  
-  private var subscriptions = Set<AnyCancellable>()
-  
   weak var delegate: BottomSheetViewDelegate?
   
   // MARK: - Lifecycle
   override init(frame: CGRect) {
     super.init(frame: frame)
     configureUI()
-    bind()
   }
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     configureUI()
-    bind()
   }
   
   convenience init() {
@@ -106,32 +99,10 @@ class BottomSheetView: UIView {
     panGesture.delaysTouchesEnded = false
     topView.addGestureRecognizer(panGesture)
   }
-  
-  private func bind() {
-    panGesturePublisher
-      .debounce(for: .milliseconds(7), scheduler: DispatchQueue.main)
-      .filter { gesture in
-        gesture.state != .ended
-      }.sink { [weak self] gesture in
-        guard let self else { return }
-          print("bb")
-          delegate?.bottomSheetView(self, withPenGesture: gesture)
-      }.store(in: &subscriptions)
-    
-    panGesturePublisher
-      .filter { gesture in
-        gesture.state == .ended
-      }
-      .receive(on: DispatchQueue.main)
-      .sink { [weak self] gesture in
-        guard let self else { return }
-        print("a")
-        delegate?.bottomSheetView(self, withPenGesture: gesture)
-      }.store(in: &subscriptions)
-  }
+
   // MARK: - Action
   @objc func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
-    panGesturePublisher.send(gesture)
+    delegate?.bottomSheetView(self, withPenGesture: gesture)
   }
 }
 

--- a/travelPlan/Source/Common/View/BottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BottomSheetView.swift
@@ -1,5 +1,5 @@
 //
-//  BaseBottomSheetView.swift
+//  BottomSheetView.swift
 //  travelPlan
 //
 //  Created by 양승현 on 2023/09/14.
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class BaseBottomSheetView: UIView {
+class BottomSheetView: UIView {
   enum Constants {
     static let cornerRadius: CGFloat = 8
     enum TopView {
@@ -81,13 +81,26 @@ class BaseBottomSheetView: UIView {
   // MARK: - Private helper
   func configureUI() {
     setupUI()
+    setGesture()
     layer.cornerRadius = Constants.cornerRadius
     clipsToBounds = true
     layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner]
   }
+  
+  func setGesture() {
+    let panGesture = UIPanGestureRecognizer(target: self, action: #selector(handlePanGesture))
+    panGesture.delaysTouchesBegan = false
+    panGesture.delaysTouchesEnded = false
+    topView.addGestureRecognizer(panGesture)
+  }
+  
+  // MARK: - Action
+  @objc func handlePanGesture(_ gesture: UIPanGestureRecognizer) {
+    print("무야호")
+  }
 }
 // MARK: - LayoutSupportable
-extension BaseBottomSheetView: LayoutSupport {
+extension BottomSheetView: LayoutSupport {
   func addSubviews() {
     _=[topView,
        topIndicatorView,
@@ -108,7 +121,7 @@ extension BaseBottomSheetView: LayoutSupport {
 }
 
 // MARK: - Layout supportable private helper
-private extension BaseBottomSheetView {
+private extension BottomSheetView {
   var topViewConstraints: [NSLayoutConstraint] {
     typealias Const = Constants.TopView
     return [

--- a/travelPlan/Source/Common/View/BottomSheetView.swift
+++ b/travelPlan/Source/Common/View/BottomSheetView.swift
@@ -137,7 +137,8 @@ private extension BottomSheetView {
       topView.trailingAnchor.constraint(
         equalTo: trailingAnchor),
       topView.topAnchor.constraint(
-        equalTo: topAnchor)]
+        equalTo: topAnchor),
+      topView.heightAnchor.constraint(equalToConstant: Const.height)]
   }
   
   var topIndicatorViewConstraints: [NSLayoutConstraint] {

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -8,6 +8,13 @@
 import UIKit
  
 class BaseBottomSheetViewController: UIViewController {
+  enum ContentMode {
+    // bottomSheet가 꽉 찬 화면
+    case full
+    // bottomSheet가 내부 tableView cell 추가로 꽉 찰 수 있는 경우
+    case couldBeFull
+  }
+  
   enum Constants {
     static let animationDuration: CGFloat = 0.43
     static let bgColor = UIColor(hex: "#000000", alpha: 0.2)
@@ -28,8 +35,19 @@ class BaseBottomSheetViewController: UIViewController {
   private var bottomSheetOriginY: CGFloat!
   
   private var bottomSheetOriginHeight: CGFloat!
+  
+  private var contentMode: ContentMode = .full
 
   // MARK: - Lifecycle
+  init(mode: ContentMode) {
+    contentMode = mode
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     setBottomSheetBeforeAnimation()
@@ -211,15 +229,17 @@ extension BaseBottomSheetViewController: LayoutSupport {
 private extension BaseBottomSheetViewController {
   var bottomSheetViewConstraints: [NSLayoutConstraint] {
     typealias Const = Constants.BottomSheetView
-    return [
+    let constraints = [
       bottomSheetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       bottomSheetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      bottomSheetView.topAnchor.constraint(
-        greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor),
-      bottomSheetView.heightAnchor.constraint(
-          greaterThanOrEqualToConstant: Const.minimumHeihgt),
       bottomSheetView.bottomAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.bottomAnchor)]
+    if contentMode == .full {
+      return constraints + [bottomSheetView.topAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.topAnchor)]
+    }
+    return constraints + [bottomSheetView.topAnchor.constraint(
+      greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor)]
   }
   
   var safeAreaBottomViewConstraints: [NSLayoutConstraint] {

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -9,6 +9,7 @@ import UIKit
  
 class BaseBottomSheetViewController: UIViewController {
   enum Constants {
+    static let animationDuration = 0.37
     static let bgColor = UIColor(hex: "#000000", alpha: 0.1)
     
     enum BottomSheetView {
@@ -31,7 +32,6 @@ class BaseBottomSheetViewController: UIViewController {
   // MARK: - Lifecycle
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    modalPresentationStyle = .overFullScreen
   }
   
   convenience init() {
@@ -40,12 +40,23 @@ class BaseBottomSheetViewController: UIViewController {
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    modalPresentationStyle = .overFullScreen
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    showViewWithAnimation()
+    showBottomSheetWithAnimation()
   }
   
   override func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
+  }
+  
+  override func viewWillDisappear(_ animated: Bool) {
+    super.viewWillDisappear(animated)
+    hideViewWithAnimation()
+    hideBottomSheetWithAnimation()
   }
   
   // MARK: - Helper
@@ -60,8 +71,50 @@ class BaseBottomSheetViewController: UIViewController {
   // MARK: - Private helper
   private func configureUI() {
     setupUI()
-    view.backgroundColor = Constants.bgColor
-    view.bringSubviewToFront(safeAreaBottomView)
+  }
+  
+  private func showViewWithAnimation() {
+    UIView.animate(
+      withDuration: Constants.animationDuration,
+      delay: 0,
+      options: .curveEaseInOut
+    ) {
+      self.view.backgroundColor = Constants.bgColor
+    }
+  }
+  
+  private func hideViewWithAnimation() {
+    UIView.animate(
+      withDuration: Constants.animationDuration,
+      delay: 0,
+      options: .curveEaseInOut
+    ) {
+      self.view.backgroundColor = .clear
+    }
+  }
+  
+  private func showBottomSheetWithAnimation() {
+    bottomSheetView.transform = .init(translationX: 0, y: self.view.bounds.height)
+    safeAreaBottomView.transform = .init(translationX: 0, y: self.view.bounds.height)
+    UIView.animate(
+      withDuration: Constants.animationDuration,
+      delay: 0,
+      options: .curveEaseInOut
+    ) {
+      self.bottomSheetView.transform = .identity
+      self.safeAreaBottomView.transform = .identity
+    }
+  }
+  
+  private func hideBottomSheetWithAnimation() {
+    UIView.animate(
+      withDuration: Constants.animationDuration,
+      delay: 0,
+      options: .curveEaseInOut
+    ) {
+      self.bottomSheetView.transform = .init(translationX: 0, y: self.view.bounds.height)
+      self.safeAreaBottomView.transform = .init(translationX: 0, y: self.view.bounds.height)
+    }
   }
 }
 

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -18,7 +18,7 @@ class BaseBottomSheetViewController: UIViewController {
   }
   
   // MARK: - Properties
-  private var bottomSheetView = BaseBottomSheetView()
+  private var bottomSheetView = BottomSheetView()
   
   private var safeAreaBottomView = UIView(frame: .zero).set {
     $0.translatesAutoresizingMaskIntoConstraints = false
@@ -53,6 +53,21 @@ class BaseBottomSheetViewController: UIViewController {
     hideViewWithAnimation()
     hideBottomSheetWithAnimation {
       super.dismiss(animated: flag, completion: completion)
+    }
+  }
+  
+  override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+    if let touch = touches.first {
+      let hitCount = view.subviews.filter {
+        let position = touch.location(in: view)
+        guard $0.frame.contains(position) else {
+          return false
+        }
+        return true
+      }.count
+      if hitCount < 1 {
+        dismiss(animated: false)
+      }
     }
   }
   

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -9,7 +9,7 @@ import UIKit
  
 class BaseBottomSheetViewController: UIViewController {
   enum Constants {
-    static let animationDuration = 0.37
+    static let animationDuration: CGFloat = 0.43
     static let bgColor = UIColor(hex: "#000000", alpha: 0.1)
     
     enum BottomSheetView {
@@ -30,12 +30,9 @@ class BaseBottomSheetViewController: UIViewController {
     .constraint(equalToConstant: Constants.BottomSheetView.minimumHeihgt)
   
   // MARK: - Lifecycle
-  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
-    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-  }
   
-  convenience init() {
-    self.init(nibName: nil, bundle: nil)
+  init() {
+    super.init(nibName: nil, bundle: nil)
   }
   
   required init?(coder: NSCoder) {
@@ -51,12 +48,14 @@ class BaseBottomSheetViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
+    DispatchQueue.main.asyncAfter(deadline: .now()+3, execute: {self.dismiss(animated: false)})
   }
   
-  override func viewWillDisappear(_ animated: Bool) {
-    super.viewWillDisappear(animated)
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
     hideViewWithAnimation()
-    hideBottomSheetWithAnimation()
+    hideBottomSheetWithAnimation {
+      super.dismiss(animated: flag, completion: completion)
+    }
   }
   
   // MARK: - Helper
@@ -89,7 +88,7 @@ class BaseBottomSheetViewController: UIViewController {
       delay: 0,
       options: .curveEaseInOut
     ) {
-      self.view.backgroundColor = .clear
+      self.view.backgroundColor = .none
     }
   }
   
@@ -106,14 +105,17 @@ class BaseBottomSheetViewController: UIViewController {
     }
   }
   
-  private func hideBottomSheetWithAnimation() {
+  private func hideBottomSheetWithAnimation(_ completion: @escaping () -> Void) {
     UIView.animate(
       withDuration: Constants.animationDuration,
       delay: 0,
-      options: .curveEaseInOut
-    ) {
+      options: .curveEaseInOut,
+      animations: {
       self.bottomSheetView.transform = .init(translationX: 0, y: self.view.bounds.height)
       self.safeAreaBottomView.transform = .init(translationX: 0, y: self.view.bounds.height)
+      }
+    ) { _ in
+      completion()
     }
   }
 }

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -13,7 +13,7 @@ class BaseBottomSheetViewController: UIViewController {
     static let bgColor = UIColor(hex: "#000000", alpha: 0.1)
     
     enum BottomSheetView {
-      static let minimumHeihgt: CGFloat = 200
+      static let minimumHeihgt: CGFloat = 50
     }
   }
   
@@ -25,18 +25,10 @@ class BaseBottomSheetViewController: UIViewController {
     $0.backgroundColor = .white
   }
   
-  private lazy var bottomSheetHeightConstraint: NSLayoutConstraint = bottomSheetView
-    .heightAnchor
-    .constraint(equalToConstant: Constants.BottomSheetView.minimumHeihgt)
-  
   private var bottomSheetOriginY: CGFloat!
   
   private var bottomSheetOriginHeight: CGFloat!
-  
-  private var isDraggingBottomSheet: Bool = false
-  
-  private var bottomSheetOriginPosition: CGRect = .zero
-  
+
   // MARK: - Lifecycle
   init() {
     super.init(nibName: nil, bundle: nil)
@@ -226,12 +218,14 @@ extension BaseBottomSheetViewController: LayoutSupport {
 // MARK: - Layout supportable private helper
 private extension BaseBottomSheetViewController {
   var bottomSheetViewConstraints: [NSLayoutConstraint] {
+    typealias Const = Constants.BottomSheetView
     return [
       bottomSheetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       bottomSheetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
       bottomSheetView.topAnchor.constraint(
         greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor),
-      bottomSheetHeightConstraint,
+      bottomSheetView.heightAnchor.constraint(
+          greaterThanOrEqualToConstant: Const.minimumHeihgt),
       bottomSheetView.bottomAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.bottomAnchor)]
   }

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -1,0 +1,85 @@
+//
+//  BaseBottomSheetViewController.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2023/09/13.
+//
+
+import UIKit
+ 
+class BaseBottomSheetViewController: UIViewController {
+  enum Constants {
+    enum BottomSheetView {
+    }
+  }
+  
+  // MARK: - Properties
+  private var bottomSheetView = BaseBottomSheetView()
+  
+  private var safeAreaBottomView = UIView(frame: .zero).set {
+    $0.translatesAutoresizingMaskIntoConstraints = false
+    $0.backgroundColor = .white
+  }
+  
+  // MARK: - Lifecycle
+  override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
+    super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
+    configureUI()
+  }
+  
+  convenience init() {
+    self.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    configureUI()
+  }
+  
+  // MARK: - Helper
+  
+  // MARK: - Private helper
+  private func configureUI() {
+    setupUI()
+  }
+}
+
+// MARK: - LayoutSupportable
+extension BaseBottomSheetViewController: LayoutSupport {
+  func addSubviews() {
+    _=[bottomSheetView,
+       safeAreaBottomView
+    ].map {
+      view.addSubview($0)
+    }
+  }
+  
+  func setConstraints() {
+    _=[bottomSheetViewConstraints,
+      safeAreaBottomViewConstraints
+    ].map {
+      NSLayoutConstraint.activate($0)
+    }
+  }
+}
+
+// MARK: - Layout supportable private helper
+private extension BaseBottomSheetViewController {
+  var bottomSheetViewConstraints: [NSLayoutConstraint] {
+    return [
+      bottomSheetView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      bottomSheetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      bottomSheetView.topAnchor.constraint(
+        greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor),
+      bottomSheetView.bottomAnchor.constraint(
+        equalTo: view.safeAreaLayoutGuide.bottomAnchor)]
+  }
+  
+  var safeAreaBottomViewConstraints: [NSLayoutConstraint] {
+    return [
+      safeAreaBottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      safeAreaBottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      safeAreaBottomView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor),
+      safeAreaBottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor)]
+  }
+}

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -9,7 +9,10 @@ import UIKit
  
 class BaseBottomSheetViewController: UIViewController {
   enum Constants {
+    static let bgColor = UIColor(hex: "#000000", alpha: 0.1)
+    
     enum BottomSheetView {
+      static let minimumHeihgt: CGFloat = 50
     }
   }
   
@@ -21,10 +24,14 @@ class BaseBottomSheetViewController: UIViewController {
     $0.backgroundColor = .white
   }
   
+  private lazy var bottomSheetHeight: NSLayoutConstraint = bottomSheetView
+    .heightAnchor
+    .constraint(equalToConstant: Constants.BottomSheetView.minimumHeihgt)
+  
   // MARK: - Lifecycle
   override init(nibName nibNameOrNil: String?, bundle nibBundleOrNil: Bundle?) {
     super.init(nibName: nibNameOrNil, bundle: nibBundleOrNil)
-    configureUI()
+    modalPresentationStyle = .overFullScreen
   }
   
   convenience init() {
@@ -33,14 +40,28 @@ class BaseBottomSheetViewController: UIViewController {
   
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    modalPresentationStyle = .overFullScreen
+  }
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
     configureUI()
   }
   
   // MARK: - Helper
+  func setContentView(_ contentView: UIView) {
+    bottomSheetView.setContentView(contentView)
+  }
+  
+  func setCornerRadius(_ radius: CGFloat) {
+    bottomSheetView.setCornerRadius(radius)
+  }
   
   // MARK: - Private helper
   private func configureUI() {
     setupUI()
+    view.backgroundColor = Constants.bgColor
+    view.bringSubviewToFront(safeAreaBottomView)
   }
 }
 
@@ -71,6 +92,7 @@ private extension BaseBottomSheetViewController {
       bottomSheetView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
       bottomSheetView.topAnchor.constraint(
         greaterThanOrEqualTo: view.safeAreaLayoutGuide.topAnchor),
+      bottomSheetHeight,
       bottomSheetView.bottomAnchor.constraint(
         equalTo: view.safeAreaLayoutGuide.bottomAnchor)]
   }
@@ -79,7 +101,7 @@ private extension BaseBottomSheetViewController {
     return [
       safeAreaBottomView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
       safeAreaBottomView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-      safeAreaBottomView.topAnchor.constraint(equalTo: bottomSheetView.bottomAnchor),
+      safeAreaBottomView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
       safeAreaBottomView.bottomAnchor.constraint(equalTo: view.bottomAnchor)]
   }
 }

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 class BaseBottomSheetViewController: UIViewController {
   enum Constants {
     static let animationDuration: CGFloat = 0.43
-    static let bgColor = UIColor(hex: "#000000", alpha: 0.1)
+    static let bgColor = UIColor(hex: "#000000", alpha: 0.2)
     
     enum BottomSheetView {
       static let minimumHeihgt: CGFloat = 50
@@ -30,14 +30,6 @@ class BaseBottomSheetViewController: UIViewController {
   private var bottomSheetOriginHeight: CGFloat!
 
   // MARK: - Lifecycle
-  init() {
-    super.init(nibName: nil, bundle: nil)
-  }
-  
-  required init?(coder: NSCoder) {
-    super.init(coder: coder)
-  }
-  
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
     setBottomSheetBeforeAnimation()
@@ -153,7 +145,7 @@ class BaseBottomSheetViewController: UIViewController {
     bottomSheetView.transform = .init(translationX: 0, y: y)
     safeAreaBottomView.transform = .init(translationX: 0, y: y)
   }
-  var i = 0
+  
   private func animateBottomSheetWithOriginPosition(_ gesture: UIPanGestureRecognizer) {
     bottomSheetView.isUserInteractionEnabled = false
     gesture.cancelsTouchesInView = true

--- a/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
+++ b/travelPlan/Source/Common/ViewController/BaseBottomSheetViewController.swift
@@ -30,7 +30,6 @@ class BaseBottomSheetViewController: UIViewController {
     .constraint(equalToConstant: Constants.BottomSheetView.minimumHeihgt)
   
   // MARK: - Lifecycle
-  
   init() {
     super.init(nibName: nil, bundle: nil)
   }
@@ -48,7 +47,6 @@ class BaseBottomSheetViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     configureUI()
-    DispatchQueue.main.asyncAfter(deadline: .now()+3, execute: {self.dismiss(animated: false)})
   }
   
   override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -105,6 +105,7 @@
 		157176752A0C09740015EC8C /* SFPro-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 157176732A0C09740015EC8C /* SFPro-Italic.ttf */; };
 		157176762A0C09740015EC8C /* SFPro.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 157176742A0C09740015EC8C /* SFPro.ttf */; };
 		157176782A0C21C90015EC8C /* UIColor+AppPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = 157176772A0C21C90015EC8C /* UIColor+AppPalette.swift */; };
+		158312E12AB36A9A0087034A /* UIViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158312E02AB36A9A0087034A /* UIViewController.swift */; };
 		158BEF772A0E279700C27861 /* PostCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BEF762A0E279700C27861 /* PostCell.swift */; };
 		158BEF792A0E27BD00C27861 /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BEF782A0E27BD00C27861 /* PostView.swift */; };
 		158BEF7D2A0E2C5F00C27861 /* PostHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 158BEF7C2A0E2C5F00C27861 /* PostHeaderView.swift */; };
@@ -138,7 +139,7 @@
 		15BB01BD2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BB01BC2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift */; };
 		15BB01BF2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BB01BE2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift */; };
 		15C83F882AB2055E00DDB536 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */; };
-		15C83F8A2AB2134D00DDB536 /* BaseBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */; };
+		15C83F8A2AB2134D00DDB536 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F892AB2134D00DDB536 /* BottomSheetView.swift */; };
 		15CB23592A109C85003EAF20 /* PostHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB23582A109C85003EAF20 /* PostHeaderModel.swift */; };
 		15CB235B2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB235A2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift */; };
 		15CB235F2A10B5B8003EAF20 /* DateValidationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB235E2A10B5B8003EAF20 /* DateValidationManager.swift */; };
@@ -293,6 +294,7 @@
 		157176732A0C09740015EC8C /* SFPro-Italic.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SFPro-Italic.ttf"; sourceTree = "<group>"; };
 		157176742A0C09740015EC8C /* SFPro.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = SFPro.ttf; sourceTree = "<group>"; };
 		157176772A0C21C90015EC8C /* UIColor+AppPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+AppPalette.swift"; sourceTree = "<group>"; };
+		158312E02AB36A9A0087034A /* UIViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIViewController.swift; sourceTree = "<group>"; };
 		158BEF762A0E279700C27861 /* PostCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCell.swift; sourceTree = "<group>"; };
 		158BEF782A0E27BD00C27861 /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
 		158BEF7C2A0E2C5F00C27861 /* PostHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderView.swift; sourceTree = "<group>"; };
@@ -328,7 +330,7 @@
 		15BB01BC2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSearchViewModel+Associatedtype.swift"; sourceTree = "<group>"; };
 		15BB01BE2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginViewModel+Associatedtype.swift"; sourceTree = "<group>"; };
 		15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
-		15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetView.swift; sourceTree = "<group>"; };
+		15C83F892AB2134D00DDB536 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		15CB23582A109C85003EAF20 /* PostHeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderModel.swift; sourceTree = "<group>"; };
 		15CB235A2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderSubInfoModel.swift; sourceTree = "<group>"; };
 		15CB235E2A10B5B8003EAF20 /* DateValidationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValidationManager.swift; sourceTree = "<group>"; };
@@ -838,7 +840,7 @@
 			isa = PBXGroup;
 			children = (
 				158BEFCF2A0FE2C000C27861 /* OneUnitHeightLine.swift */,
-				15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */,
+				15C83F892AB2134D00DDB536 /* BottomSheetView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1293,6 +1295,7 @@
 				158BEFC32A0EC8A100C27861 /* UIView+CustomAnimation.swift */,
 				15AF2C3D2A1147B100BEE166 /* UIImage+JPEGCompress.swift */,
 				13CB6D352A20E12B00D185B2 /* CALayer+Border.swift */,
+				158312E02AB36A9A0087034A /* UIViewController.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1577,7 +1580,7 @@
 				15FEB5E72A050A99000A5F33 /* UIButton+Combine.swift in Sources */,
 				15332AD62A163AB6008A4110 /* FavoriteViewControllerConstant.swift in Sources */,
 				152AD51B2A1A0447008A2A11 /* FavoriteListTableViewAdapter.swift in Sources */,
-				15C83F8A2AB2134D00DDB536 /* BaseBottomSheetView.swift in Sources */,
+				15C83F8A2AB2134D00DDB536 /* BottomSheetView.swift in Sources */,
 				1503F92B2A4E068E002BC38D /* ApplicationCoordinator.swift in Sources */,
 				13813A212AAA458000AF6AEB /* PostSearchCollectionViewDataSource.swift in Sources */,
 				15F0D1B42A51BFB800D04773 /* PostSearchCoordiantor.swift in Sources */,
@@ -1604,6 +1607,7 @@
 				15FEB5E62A050A99000A5F33 /* UISwitch+Combine.swift in Sources */,
 				132550282A0ABBDA00094218 /* PostSearchSectionItemModel.swift in Sources */,
 				15EF8C9B2A0A19100068C744 /* CategoryView.swift in Sources */,
+				158312E12AB36A9A0087034A /* UIViewController.swift in Sources */,
 				13606E922A9F987000365F20 /* PostRecommendationSearchHeaderView+Constants.swift in Sources */,
 				132C2D3A2A84394300B587E8 /* PostRecommendationSearchTagCell+Constants.swift in Sources */,
 				15CB23742A110FB4003EAF20 /* PostViewModel.swift in Sources */,
@@ -1921,7 +1925,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BH624LXP8S;
+				DEVELOPMENT_TEAM = 4GW2K8FK25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Source/Support/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -1950,7 +1954,7 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = BH624LXP8S;
+				DEVELOPMENT_TEAM = 4GW2K8FK25;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Source/Support/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -137,6 +137,8 @@
 		15BB01BB2A1EB6300035B486 /* FeedViewModel+AssociatedType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BB01BA2A1EB6300035B486 /* FeedViewModel+AssociatedType.swift */; };
 		15BB01BD2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BB01BC2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift */; };
 		15BB01BF2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15BB01BE2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift */; };
+		15C83F882AB2055E00DDB536 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */; };
+		15C83F8A2AB2134D00DDB536 /* BaseBottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */; };
 		15CB23592A109C85003EAF20 /* PostHeaderModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB23582A109C85003EAF20 /* PostHeaderModel.swift */; };
 		15CB235B2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB235A2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift */; };
 		15CB235F2A10B5B8003EAF20 /* DateValidationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB235E2A10B5B8003EAF20 /* DateValidationManager.swift */; };
@@ -325,6 +327,8 @@
 		15BB01BA2A1EB6300035B486 /* FeedViewModel+AssociatedType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedViewModel+AssociatedType.swift"; sourceTree = "<group>"; };
 		15BB01BC2A1EB7640035B486 /* PostSearchViewModel+Associatedtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PostSearchViewModel+Associatedtype.swift"; sourceTree = "<group>"; };
 		15BB01BE2A1EBAC20035B486 /* LoginViewModel+Associatedtype.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LoginViewModel+Associatedtype.swift"; sourceTree = "<group>"; };
+		15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
+		15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetView.swift; sourceTree = "<group>"; };
 		15CB23582A109C85003EAF20 /* PostHeaderModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderModel.swift; sourceTree = "<group>"; };
 		15CB235A2A109CA4003EAF20 /* PostHeaderSubInfoModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderSubInfoModel.swift; sourceTree = "<group>"; };
 		15CB235E2A10B5B8003EAF20 /* DateValidationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateValidationManager.swift; sourceTree = "<group>"; };
@@ -395,6 +399,7 @@
 			isa = PBXGroup;
 			children = (
 				13CB6D312A1E9F6600D185B2 /* CautionAlertViewController.swift */,
+				15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */,
 			);
 			path = ViewController;
 			sourceTree = "<group>";
@@ -833,6 +838,7 @@
 			isa = PBXGroup;
 			children = (
 				158BEFCF2A0FE2C000C27861 /* OneUnitHeightLine.swift */,
+				15C83F892AB2134D00DDB536 /* BaseBottomSheetView.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -1571,6 +1577,7 @@
 				15FEB5E72A050A99000A5F33 /* UIButton+Combine.swift in Sources */,
 				15332AD62A163AB6008A4110 /* FavoriteViewControllerConstant.swift in Sources */,
 				152AD51B2A1A0447008A2A11 /* FavoriteListTableViewAdapter.swift in Sources */,
+				15C83F8A2AB2134D00DDB536 /* BaseBottomSheetView.swift in Sources */,
 				1503F92B2A4E068E002BC38D /* ApplicationCoordinator.swift in Sources */,
 				13813A212AAA458000AF6AEB /* PostSearchCollectionViewDataSource.swift in Sources */,
 				15F0D1B42A51BFB800D04773 /* PostSearchCoordiantor.swift in Sources */,
@@ -1654,6 +1661,7 @@
 				13C9C1AF2A17FFC400DF1FFF /* PostSearchHeaderViewDelegate.swift in Sources */,
 				13254FFB2A08AD8700094218 /* PostSearchViewController.swift in Sources */,
 				15EF8CA12A0A19380068C744 /* CategoryDetailViewCell.swift in Sources */,
+				15C83F882AB2055E00DDB536 /* BaseBottomSheetViewController.swift in Sources */,
 				15710CBC2A132DD00023C19E /* FeedAppLogoBarItem.swift in Sources */,
 				132C2D212A83468E00B587E8 /* SearchView+Constants.swift in Sources */,
 				152AD4EB2A1890FD008A2A11 /* FavoriteListTableViewCellConstant.swift in Sources */,


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- BaseBottomSheetViewController 구현 ( 후기 writing 등록 위치, 지역 화면, 피드 소팅 화면에 사용 가능 )
- BottomSheetView 구현( 찜 편집 폴더 변경할 때 재 사용 가능 )

### ContentMode
- couldBeFull의 경우 contentView에 추가될 높이가 지정되면 좋습니다. 
그렇지 않는 경우 priority를 지정하지 않으면 특정 뷰의 높이가 커지거나 압축될 수 있습니다.

https://github.com/IF-TG/iOS/assets/96910404/cb0cce3e-f2b4-45bc-8e62-d7122263a303

- Full의 경우 높이를 지정하지 않을 경우 오토 레이아웃에 의해 꽉 찬 화면 기반으로 레이아웃 됩니다.

https://github.com/IF-TG/iOS/assets/96910404/ba97b7e4-5e49-440e-a9f7-377857d7f880


## ✨ [사용 방법]

- BaseBottomSheetViewController를 상속받는 커스텀 클래스를 생성합니다.
- containerView인 contentView를 생성합니다.
- 실제 컨텐츠가 담길 뷰들을 선언 후 contentView's subview로 추가합니다.
- viewDidLoad시점에
- setContentView() 함수에 넣습니다.
- UIViewController클래스의 presentBottomSheet()를 이용해 화면 전환합니다.
- 이때 ContentMode는 Full, CouldBeFull 두가지가 있습니다. 전자의 경우 화면 전환 시 bottomSheet는 전체 사이즈 layout을 갖게 됩니다. 후자의 경우 full이 되지 않는 경우에 사용될 수 있고, 테이블 뷰의 cell이 추가되 bottomSheet가 전체 화면으로 확장될 수 있는 경우에도 사용할 수 있습니다.

### BigLabelBottomSheetViewController

![image](https://github.com/IF-TG/iOS/assets/96910404/9e23d29d-af84-46fb-92ba-8a49d0665f54)
![image](https://github.com/IF-TG/iOS/assets/96910404/d251cea7-0ea4-431b-8732-9e8c4acb103e)

### Coordinator
![image](https://github.com/IF-TG/iOS/assets/96910404/07319466-0908-4706-9116-b62612226ebc)

여기서 버튼을 통해 화면 전환하지 않고 피드 화면 후 1초뒤 화면 전환을 수행했기에 DispatchQueue.main.asyncAfter는 임시 호출 코드 입니다.

## 📸  [스크린샷(선택)]

*<!-- 스크린샷이 필요하면 스크린샷을 첨부해주세요 -->*

## 📚 [마주한 오류]

처음에 이벤트를 발생중인 gesture.translatation(in:)을 통해 특정 뷰가 현재 어느 좌표로 멀리 떨어져 제스쳐되는지에 따라 bottomSheetView의 frame을 바로바로 새롭게 지정했습니다.

https://github.com/IF-TG/iOS/assets/96910404/17120c20-78c6-4bea-b7d8-d97ebe05f469


이 경우 단점은 제스쳐 속도를 빠르게 할 경우 gesture.state가 .ended가 되지 않고 .changed상태로 지속됩니다. 손을 떄도 .ended호출이 안되서는 문제가 생겼습니다.

드래그 중인 손을 땠다고 해도 view render cycle보다 빨리 제스쳐 델리게이트 함수가 호출되서 bottomSheetView의 frame은 제자리로 됬지만, 애니메이션이 동작되어 화면에 그려지지 않는 문제가 있었습니다.

그래서 레이아웃을 그리지 않는 CGAffineTransform을 사용했고 해결했습니다.
