### PR TITLE
[Rebuild] 여가 팔래트를 Support-> palette asset으로 변경했습니다.

### DIFF
--- a/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
+++ b/travelPlan/Source/Common/Extension/UIColor+AppPalette.swift
@@ -8,7 +8,8 @@
 import UIKit
 
 extension UIColor {
-  typealias yg = YG
+  typealias yg = YeoGa
+  typealias YG = YeoGa
   /// YG app에서 사용되는 palette
   /// Example:
   /// ```
@@ -18,54 +19,55 @@ extension UIColor {
   /// view.backgroundColor = .YG.gray0
   /// view.backgroundColor = UIColor.yg.gray0
   /// ```
-  enum YG {
+  enum YeoGa {
     // MARK: - Gray
     /// #F9F9F9
-    static let gray00Background = UIColor(
-      red: 0.975, green: 0.975, blue: 0.975, alpha: 1)
+    static let gray00Background = UIColor(named: "gray0Background")!
+    
     /// #F2F0F0
-    static let veryLightGray = UIColor(
-      red: 0.949, green: 0.941, blue: 0.941, alpha: 1)
+    static let veryLightGray = UIColor(named: "gray0VeryLight")!
+    
     /// #D9D9D9
-    static let gray0 = UIColor(
-      red: 0.851, green: 0.851, blue: 0.851, alpha: 1)
+    static let gray0 = UIColor(named: "gray0")!
+    
     /// #C9C9C9
-    static let gray1 = UIColor(
-      red: 0.788, green: 0.788, blue: 0.788, alpha: 1)
+    static let gray1 = UIColor(named: "gray1")!
+    
     /// #B4B4B4
-    static let gray2 = UIColor(
-      red: 0.704, green: 0.704, blue: 0.704, alpha: 1)
+    static let gray2 = UIColor(named: "gray2")!
+      
     /// #717171
-    static let gray3 = UIColor(
-      red: 0.443, green: 0.443, blue: 0.443, alpha: 1)
+    static let gray3 = UIColor(named: "gray3")!
+    
     /// #676767
-    static let gray4 = UIColor(
-      red: 0.404, green: 0.404, blue: 0.404, alpha: 1)
+    static let gray4 = UIColor(named: "gray4")!
+    
     /// #484848
-    static let gray5 = UIColor(
-      red: 0.283, green: 0.283, blue: 0.283, alpha: 1)
+    static let gray5 = UIColor(named: "gray5")!
+    
     /// #4B4B4B
-    static let gray6 = UIColor(
-      red: 0.294, green: 0.294, blue: 0.294, alpha: 1)
+    static let gray6 = UIColor(named: "gray6")!
+    
     /// #333333
-    static let gray7 = UIColor(
-      red: 0.2, green: 0.2, blue: 0.2, alpha: 1)
+    static let gray7 = UIColor(named: "gray7")!
     
     // MARK: - brand color
     /// #1BA0EB
-    static let primary = UIColor(
-      red: 0.106, green: 0.627, blue: 0.922, alpha: 1)
+    static let primary = UIColor(named: "primary")!
+    
     /// #FE0135
-    static let red = UIColor(
-      red: 0.996, green: 0.004, blue: 0.208, alpha: 1)
+    static let red = UIColor(named: "yeogaRed")!
+    
     /// #EE0031
-    static let red2 = UIColor(
-      red: 0.933, green: 0, blue: 0.192, alpha: 1)
+    static let red2 = UIColor(named: "yeogaRed2")!
+    
     /// #0072C6
-    static let highlight = UIColor(hex: "0072C6", alpha: 1)
+    static let highlight = UIColor(named: "highlight")!
+                              
     /// #FBFBFB
-    static let littleWhite = UIColor(hex: "#FBFBFB", alpha: 1)
+    static let littleWhite = UIColor(named: "littleWhite")!
+    
     /// #FEE500
-    static let kakao = UIColor(hex: "#FEE500")
+    static let kakao = UIColor(named: "kakaoPrimary")!
   }
 }

--- a/travelPlan/Source/Support/Palette.xcassets/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray0.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray0.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.851",
+          "green" : "0.851",
+          "red" : "0.851"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.851",
+          "green" : "0.851",
+          "red" : "0.851"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray0Background.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray0Background.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.975",
+          "green" : "0.975",
+          "red" : "0.975"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.975",
+          "green" : "0.975",
+          "red" : "0.975"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray0VeryLight.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray0VeryLight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.941",
+          "green" : "0.941",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.941",
+          "green" : "0.941",
+          "red" : "0.949"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray1.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray1.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.788",
+          "green" : "0.788",
+          "red" : "0.788"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.788",
+          "green" : "0.788",
+          "red" : "0.788"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray2.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.704",
+          "green" : "0.704",
+          "red" : "0.704"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.704",
+          "green" : "0.704",
+          "red" : "0.704"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray3.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray3.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.443",
+          "green" : "0.443",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.443",
+          "green" : "0.443",
+          "red" : "0.443"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray4.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray4.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.404",
+          "green" : "0.404",
+          "red" : "0.404"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.404",
+          "green" : "0.404",
+          "red" : "0.404"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray5.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray5.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.283",
+          "green" : "0.283",
+          "red" : "0.283"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.283",
+          "green" : "0.283",
+          "red" : "0.283"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray6.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray6.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.294",
+          "green" : "0.294",
+          "red" : "0.294"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.294",
+          "green" : "0.294",
+          "red" : "0.294"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/gray7.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/gray7.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.200",
+          "green" : "0.200",
+          "red" : "0.200"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/highlight.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/highlight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.776",
+          "green" : "0.447",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.776",
+          "green" : "0.447",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/kakaoPrimary.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/kakaoPrimary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.898",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.000",
+          "green" : "0.898",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/littleWhite.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/littleWhite.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.984",
+          "red" : "0.984"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.984",
+          "green" : "0.984",
+          "red" : "0.984"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/primary.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/primary.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.922",
+          "green" : "0.627",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.922",
+          "green" : "0.627",
+          "red" : "0.106"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/yeogaRed.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/yeogaRed.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.004",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.208",
+          "green" : "0.004",
+          "red" : "0.996"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/Source/Support/Palette.xcassets/yeogaRed2.colorset/Contents.json
+++ b/travelPlan/Source/Support/Palette.xcassets/yeogaRed2.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.000",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.192",
+          "green" : "0.000",
+          "red" : "0.933"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -1297,7 +1297,6 @@
 		1594F52529FD517E00A58F20 = {
 			isa = PBXGroup;
 			children = (
-				13BF411C2ADBE42000F3F082 /* onboarding-video.mp4 */,
 				15F0A3F429FD58280049AB33 /* .swiftlint.yml */,
 				1594F53029FD517E00A58F20 /* Source */,
 				151130072A04E4EB0041DDA1 /* travelPlanTests */,
@@ -1336,6 +1335,7 @@
 			isa = PBXGroup;
 			children = (
 				157176702A0BFA2F0015EC8C /* Fonts */,
+				13BF411C2ADBE42000F3F082 /* onboarding-video.mp4 */,
 				1594F53129FD517E00A58F20 /* AppDelegate.swift */,
 				1594F53F29FD517F00A58F20 /* Info.plist */,
 				1594F53A29FD517F00A58F20 /* Assets.xcassets */,

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@
 		1594F53429FD517E00A58F20 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1594F53329FD517E00A58F20 /* SceneDelegate.swift */; };
 		1594F53B29FD517F00A58F20 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53A29FD517F00A58F20 /* Assets.xcassets */; };
 		1594F53E29FD517F00A58F20 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53C29FD517F00A58F20 /* LaunchScreen.storyboard */; };
+		159958762B0D988400B2E4DC /* Palette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 159958752B0D988400B2E4DC /* Palette.xcassets */; };
 		159F38BB2AFA9F32000A24C2 /* PostDetailCategoryHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159F38BA2AFA9F32000A24C2 /* PostDetailCategoryHeaderView.swift */; };
 		159F38BD2AFAA1F7000A24C2 /* PostDetailCategoryHeaderViewDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159F38BC2AFAA1F7000A24C2 /* PostDetailCategoryHeaderViewDelegate.swift */; };
 		159F38BF2AFAA329000A24C2 /* PostDetailTitleCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159F38BE2AFAA329000A24C2 /* PostDetailTitleCell.swift */; };
@@ -519,6 +520,7 @@
 		1594F53A29FD517F00A58F20 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1594F53D29FD517F00A58F20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1594F53F29FD517F00A58F20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		159958752B0D988400B2E4DC /* Palette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Palette.xcassets; sourceTree = "<group>"; };
 		159F38BA2AFA9F32000A24C2 /* PostDetailCategoryHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailCategoryHeaderView.swift; sourceTree = "<group>"; };
 		159F38BC2AFAA1F7000A24C2 /* PostDetailCategoryHeaderViewDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailCategoryHeaderViewDelegate.swift; sourceTree = "<group>"; };
 		159F38BE2AFAA329000A24C2 /* PostDetailTitleCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostDetailTitleCell.swift; sourceTree = "<group>"; };
@@ -1339,6 +1341,7 @@
 				1594F53A29FD517F00A58F20 /* Assets.xcassets */,
 				1594F53C29FD517F00A58F20 /* LaunchScreen.storyboard */,
 				1594F53329FD517E00A58F20 /* SceneDelegate.swift */,
+				159958752B0D988400B2E4DC /* Palette.xcassets */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -2016,6 +2019,7 @@
 				158BEFBB2A0EB2A500C27861 /* Pretendard-Regular.ttf in Resources */,
 				15F0A3F529FD58280049AB33 /* .swiftlint.yml in Resources */,
 				1594F53E29FD517F00A58F20 /* LaunchScreen.storyboard in Resources */,
+				159958762B0D988400B2E4DC /* Palette.xcassets in Resources */,
 				158BEFBC2A0EB2A500C27861 /* Pretendard-SemiBold.ttf in Resources */,
 				158BEFBF2A0EB2A500C27861 /* Pretendard-Thin.ttf in Resources */,
 				158BEFBA2A0EB2A500C27861 /* Pretendard-Bold.ttf in Resources */,


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- 색을 한눈에 볼 수 있도록 에셋으로 추가하도록 리빌딩
- 온보딩 영상 Support 디렉터리로 이전

- 온보딩 영상의 크기를 아이폰 프로맥스 size + 100씩 리사이즈 한 다음에 다시 올려도 좋을거같습니다. 지금 파이널컷이 막혀서,,나중에 시도하려구합니다.ㅠㅅㅠ

## 📸  [스크린샷(선택)]

![image](https://github.com/IF-TG/iOS/assets/96910404/7fea8f0f-62c1-4702-acbe-e3323c77548c)


## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

- 에셋 추가 kimdee님(<a href="https://kimdee.tistory.com/entry/Swift-%EC%82%AC%EC%9A%A9%EC%9E%90-%EC%BB%AC%EB%9F%AC%EC%85%8B-%EC%B6%94%EA%B0%80%ED%95%98%EA%B3%A0-UI-Color-%ED%99%95%EC%9E%A5%ED%95%98%EC%97%AC-%EC%BD%94%EB%93%9C%EB%A1%9C-%EC%A0%91%EA%B7%BC%ED%95%98%EA%B2%8C-%EB%A7%8C%EB%93%A4%EA%B8%B0">관련 포스트</a>)
