### PR TITLE
[Feature] 사용자 닉네임 변경시 중복 여부 useCase를 Presentation layer에 적용 및 테스트

### DIFF
--- a/travelPlan/Source/Core/Network/Module/Endpoint.swift
+++ b/travelPlan/Source/Core/Network/Module/Endpoint.swift
@@ -17,7 +17,6 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
   var requestType: RequestType
   var headers: HTTPHeaders?
   var interceptor: RequestInterceptor?
-  var timeout: Int
   
   // MARK: - Lifecycle
   init(
@@ -28,7 +27,6 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     parameters: Encodable?,
     requestType: RequestType,
     headers: HTTPHeaders? = ["Content-Type": "application/json"],
-    timeout: Int = 15,
     interceptor: RequestInterceptor? = nil
   ) {
     self.scheme = scheme
@@ -38,7 +36,6 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     self.parameters = parameters
     self.requestType = requestType
     self.headers = headers
-    self.timeout = timeout
     self.interceptor = interceptor
   }
 }

--- a/travelPlan/Source/Core/Network/Module/Endpoint.swift
+++ b/travelPlan/Source/Core/Network/Module/Endpoint.swift
@@ -17,6 +17,7 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
   var requestType: RequestType
   var headers: HTTPHeaders?
   var interceptor: RequestInterceptor?
+  var timeout: Int
   
   // MARK: - Lifecycle
   init(
@@ -27,6 +28,7 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     parameters: Encodable?,
     requestType: RequestType,
     headers: HTTPHeaders? = ["Content-Type": "application/json"],
+    timeout: Int = 15,
     interceptor: RequestInterceptor? = nil
   ) {
     self.scheme = scheme
@@ -36,6 +38,7 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     self.parameters = parameters
     self.requestType = requestType
     self.headers = headers
+    self.timeout = timeout
     self.interceptor = interceptor
   }
 }

--- a/travelPlan/Source/Core/Network/Module/SessionProvider.swift
+++ b/travelPlan/Source/Core/Network/Module/SessionProvider.swift
@@ -11,8 +11,11 @@ import Foundation
 
 final class SessionProvider {
   let session: Session
-  init(session: Session = .default) {
+  private let timeout: Double
+  init(session: Session = .default, timeout: Double = 30) {
     self.session = session
+    self.timeout = timeout
+    session.sessionConfiguration.timeoutIntervalForRequest = timeout
   }
 }
 

--- a/travelPlan/Source/Core/Network/Tests/Mocks/MockSession.swift
+++ b/travelPlan/Source/Core/Network/Tests/Mocks/MockSession.swift
@@ -11,6 +11,7 @@ import Foundation
 class MockSession {
   static var `default`: Session {
     let configuration = URLSessionConfiguration.af.default
+    configuration.timeoutIntervalForRequest = 3
     configuration.protocolClasses = [MockUrlProtocol.self] + (configuration.protocolClasses ?? [])
     return Session(configuration: configuration)
   }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -10,7 +10,7 @@ import XCTest
 
 final class UserInfoAPIEndpointTests: XCTestCase {
   // MARK: - Properties
-  var sut: UserInfoAPIEndpoint = UserInfoAPIEndpoint.default
+  typealias sut = UserInfoAPIEndpoint
   let mockSession = MockSession.default
   var expectation: XCTestExpectation!
   

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -6,32 +6,41 @@
 //
 
 import XCTest
+import Combine
 @testable import travelPlan
 
 final class UserInfoUseCaseTests: XCTestCase {
   // MARK: - Properties
   var sut: UserInfoUseCase!
+  var subscription: AnyCancellable?
   let mockUserInfoRepository = MockUserInfoRepository()
+  var expectation: XCTestExpectation!
   
   // MARK: - Lifecycle
   override func setUp() {
     super.setUp()
     sut = DefaultUserInfoUseCase(userInfoRepository: mockUserInfoRepository)
+    expectation = XCTestExpectation(description: "Finish")
   }
   
   override func tearDown() {
     super.tearDown()
     sut = nil
+    subscription = nil
+    expectation = nil
   }
   
   // MARK: - Tests
   func testUserInfoUseCase_사용자의이름이중복됬는지여부를확인할때_ShouldRetrunTrue() {
+    subscription = sut.isDuplicatedName.sink { [unowned self] requestedValue in
+      // Assert
+      XCTAssertTrue(requestedValue, "isDuplicatedName 변수 반환값이 true여야 하지만 false 반환")
+      expectation.fulfill()
+    }
+    
     // Act
     sut.isDuplicatedName(with: "토익은 어려워")
-    let requestedValue = sut.isDuplicatedName
     
-    // Assert
-    XCTAssertNotNil(requestedValue, "isDuplicatedName 변수 반환값이 bool이어야 하는데 옵셔널 값임")
-    XCTAssertTrue(requestedValue!, "isDuplicatedName 변수 반환값이 true여야 하지만 false 반환")
+    wait(for: [expectation], timeout: 5)
   }
 }

--- a/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
@@ -12,7 +12,7 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
   private let userInfoRepository: UserInfoRepository
   
   // MARK: - Properties
-  @Published var isDuplicatedName: Bool?
+  var isDuplicatedName = PassthroughSubject<Bool, Never>()
   
   var subscription: AnyCancellable?
   
@@ -23,7 +23,7 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
   
   func isDuplicatedName(with name: String) {
     subscription = userInfoRepository.isDuplicatedName(with: name).sink { [weak self] in
-      self?.isDuplicatedName = $0
+      self?.isDuplicatedName.send($0)
     }
   }
 }

--- a/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
@@ -8,6 +8,6 @@
 import Combine
 
 protocol UserInfoUseCase {
-  var isDuplicatedName: Bool? { get }
+  var isDuplicatedName: PassthroughSubject<Bool, Never> { get }
   func isDuplicatedName(with name: String)
 }

--- a/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
+++ b/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
@@ -42,8 +42,21 @@ extension ProfileCoordinator: ProfileCoordinatorDelegate {
   }
   
   func showMyInformationPage() {
-    let session = SessionProvider(session: .default)
-    let userInfoRepository = DefaultUserInfoRepository(service: session)
+    let sessionConfiguration = URLSessionConfiguration.default
+    sessionConfiguration.timeoutIntervalForRequest = 5
+    let monitor = ClosureEventMonitor()
+    monitor.requestDidResume = { request in print("MyInformationVC task 요청 시자그!: \(request)") }
+    monitor.requestDidFinish = { request in print("MyInformationVC 요청 끝: \(request)") }
+    monitor.taskDidComplete = { _, _, error in
+      if let error = error {
+        print("Task completed with error: \(error)")
+      } else {
+        print("Task completed successfully")
+      }
+    }
+    let session = Session(configuration: sessionConfiguration, eventMonitors: [monitor])
+    let sessionProvider = SessionProvider(session: session)
+    let userInfoRepository = DefaultUserInfoRepository(service: sessionProvider)
     let userInfoUseCase = DefaultUserInfoUseCase(userInfoRepository: userInfoRepository)
     let viewModel = MyInformationViewModel(userInfoUseCase: userInfoUseCase)
     let viewController = MyInformationViewController(viewModel: viewModel)

--- a/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
+++ b/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
@@ -54,8 +54,23 @@ extension ProfileCoordinator: ProfileCoordinatorDelegate {
         print("Task completed successfully")
       }
     }
+    // Mock session주입
+    let mockSession = MockSession.default
+    let json = """
+      {
+        "result": false,
+        "status": "OK",
+        "statusCode": "200",
+        "message": "success"
+      }
+      """
+    MockUrlProtocol.requestHandler = { _ in
+      let responseData = json.data(using: .utf8)!
+      return ((HTTPURLResponse(), responseData))
+    }
     let session = Session(configuration: sessionConfiguration, eventMonitors: [monitor])
-    let sessionProvider = SessionProvider(session: session)
+    
+    let sessionProvider = SessionProvider(session: mockSession)
     let userInfoRepository = DefaultUserInfoRepository(service: sessionProvider)
     let userInfoUseCase = DefaultUserInfoUseCase(userInfoRepository: userInfoRepository)
     let viewModel = MyInformationViewModel(userInfoUseCase: userInfoUseCase)

--- a/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
+++ b/travelPlan/Source/Feature/Profile/Coordinator/ProfileCoordinator.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 import SHCoordinator
+import Alamofire
 
 protocol ProfileCoordinatorDelegate: AnyObject {
   func finish()
@@ -41,7 +42,11 @@ extension ProfileCoordinator: ProfileCoordinatorDelegate {
   }
   
   func showMyInformationPage() {
-    let viewController = MyInformationViewController()
+    let session = SessionProvider(session: .default)
+    let userInfoRepository = DefaultUserInfoRepository(service: session)
+    let userInfoUseCase = DefaultUserInfoUseCase(userInfoRepository: userInfoRepository)
+    let viewModel = MyInformationViewModel(userInfoUseCase: userInfoUseCase)
+    let viewController = MyInformationViewController(viewModel: viewModel)
     presenter?.pushViewController(viewController, animated: true)
   }
   

--- a/travelPlan/Source/Feature/Profile/Protocol/MyInformationViewModelable.swift
+++ b/travelPlan/Source/Feature/Profile/Protocol/MyInformationViewModelable.swift
@@ -1,0 +1,13 @@
+//
+//  MyInformationViewModelable.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2/28/24.
+//
+
+import Combine
+
+protocol MyInformationViewModelable: ViewModelable
+where Input == MyInformationViewModel.Input,
+      State == MyInformationViewModel.State,
+      Output == AnyPublisher<State, Never> { }

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -100,25 +100,7 @@ extension MyInformationViewController: ViewBindCase {
   typealias State = MyInformationViewModel.State
   
   func bind() {
-    inputTextField
-      .changed
-      .debounce(for: 0.2, scheduler: RunLoop.main)
-      .sink { [weak self] in
-        if (3...15).contains($0.count) {
-          self?.input.isDuplicatedUserName.send($0)
-        } else if $0.count == 0 || $0.isEmpty {
-          self?.inputTextField.textState = .initial
-        } else if (1...3).contains($0.count) {
-          /// 닉네임 글자 최소 넘지 못함.
-          self?.inputTextField.textState = .underflow
-          self?.inputNoticeLabel.textColor = .yg.red2
-        } else {
-          /// 닉네임 글자 넘음
-          self?.inputTextField.textState = .overflow
-          self?.inputNoticeLabel.textColor = .yg.red2
-        }
-        self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
-      }.store(in: &subscriptions)
+        bindInputTextField()
   }
   
   func render(_ state: MyInformationViewModel.State) {
@@ -141,6 +123,28 @@ extension MyInformationViewController: ViewBindCase {
 
 // MARK: - Private Helpers
 private extension MyInformationViewController {
+  func bindInputTextField() {
+    inputTextField
+      .changed
+      .debounce(for: 0.2, scheduler: RunLoop.main)
+      .sink { [weak self] in
+        if (3...15).contains($0.count) {
+          self?.input.isDuplicatedUserName.send($0)
+        } else if $0.count == 0 || $0.isEmpty {
+          self?.inputTextField.textState = .initial
+        } else if (1...3).contains($0.count) {
+          /// 닉네임 글자 최소 넘지 못함.
+          self?.inputTextField.textState = .underflow
+          self?.inputNoticeLabel.textColor = .yg.red2
+        } else {
+          /// 닉네임 글자 넘음
+          self?.inputTextField.textState = .overflow
+          self?.inputNoticeLabel.textColor = .yg.red2
+        }
+        self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
+      }.store(in: &subscriptions)
+  }
+  
   func configureUI() {
     modalPresentationStyle = .fullScreen
     view.backgroundColor = .yg.gray00Background

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -80,6 +80,50 @@ final class MyInformationViewController: UIViewController {
   }
 }
 
+// MARK: - ViewBindCase
+extension MyInformationViewController: ViewBindCase {
+  typealias Input = MyInformationViewModel.Input
+  typealias ErrorType = Error
+  typealias State = MyInformationViewModel.State
+  
+  func bind() {
+    inputTextField
+      .changed
+      .debounce(for: 0.2, scheduler: RunLoop.main)
+      .sink { [weak self] in
+        if (3...15).contains($0.count) {
+          // TODO: - 서버에 이 이름을 가진 유저가 있는지 체크 후 inputTextField 상태 변경해야합니다.
+          self?.inputTextField.textState = .available
+          self?.inputNoticeLabel.textColor = .yg.primary
+          self?.storeLabel.isUserInteractionEnabled = true
+          self?.storeLabel.textColor = .yg.primary
+        } else if $0.count == 0 || $0.isEmpty {
+          self?.inputTextField.textState = .initial
+        } else if (1...3).contains($0.count) {
+          self?.inputTextField.textState = .underflow
+          self?.inputNoticeLabel.textColor = .yg.red2
+        } else {
+          self?.inputTextField.textState = .overflow
+          self?.inputNoticeLabel.textColor = .yg.red2
+        }
+        if self?.inputTextField.textState != .available {
+          self?.storeLabel.isUserInteractionEnabled = false
+          self?.storeLabel.textColor = .yg.gray1
+        }
+        self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
+      }.store(in: &subscriptions)
+  }
+  
+  func render(_ state: MyInformationViewModel.State) {
+    switch state {
+    case .none:
+      break
+    }
+  }
+  
+  func handleError(_ error: ErrorType) { }
+}
+
 // MARK: - Private Helpers
 private extension MyInformationViewController {
   func configureUI() {
@@ -128,35 +172,6 @@ private extension MyInformationViewController {
   
   func setNaviRightBarButton() {
     navigationItem.rightBarButtonItem = UIBarButtonItem(customView: storeLabel)
-  }
-  
-  func bind() {
-    inputTextField
-      .changed
-      .debounce(for: 0.2, scheduler: RunLoop.main)
-      .sink { [weak self] in
-        if (3...15).contains($0.count) {
-          // TODO: - 서버에 이 이름을 가진 유저가 있는지 체크 후 inputTextField 상태 변경해야합니다.
-          // 이때 네비바 '저장' 레이블 상태도 변경해야합니다.
-          self?.inputTextField.textState = .available
-          self?.inputNoticeLabel.textColor = .yg.primary
-          self?.storeLabel.isUserInteractionEnabled = true
-          self?.storeLabel.textColor = .yg.primary
-        } else if $0.count == 0 || $0.isEmpty {
-          self?.inputTextField.textState = .initial
-        } else if (1...3).contains($0.count) {
-          self?.inputTextField.textState = .underflow
-          self?.inputNoticeLabel.textColor = .yg.red2
-        } else {
-          self?.inputTextField.textState = .overflow
-          self?.inputNoticeLabel.textColor = .yg.red2
-        }
-        if self?.inputTextField.textState != .available {
-          self?.storeLabel.isUserInteractionEnabled = false
-          self?.storeLabel.textColor = .yg.gray1
-        }
-        self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
-    }.store(in: &subscriptions)
   }
   
   func setSubviewsDefaultUI() {

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -100,7 +100,9 @@ extension MyInformationViewController: ViewBindCase {
   typealias State = MyInformationViewModel.State
   
   func bind() {
-        bindInputTextField()
+    bindInputTextField()
+    let output = viewModel.transform(input)
+    output.sink { [weak self] in self?.render($0) }.store(in: &subscriptions)
   }
   
   func render(_ state: MyInformationViewModel.State) {

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -59,6 +59,8 @@ final class MyInformationViewController: UIViewController {
     $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapStoreLabel)))
   }
   
+  private let input = MyInformationViewModel.Input()
+  
   private let viewModel: any MyInformationViewModelable
   
   private var subscriptions = Set<AnyCancellable>()
@@ -103,14 +105,7 @@ extension MyInformationViewController: ViewBindCase {
       .debounce(for: 0.2, scheduler: RunLoop.main)
       .sink { [weak self] in
         if (3...15).contains($0.count) {
-          // TODO: - 서버에 이 이름을 가진 유저가 있는지 체크 후 inputTextField 상태 변경해야합니다.
-          
-          /// 이용가능한 글인 경우 서버에 중복 여부 확인하기
-          self?.inputTextField.textState = .available
-          self?.inputNoticeLabel.textColor = .yg.primary
-          self?.storeLabel.isUserInteractionEnabled = true
-          self?.storeLabel.textColor = .yg.primary
-          
+          self?.input.isDuplicatedUserName.send($0)
         } else if $0.count == 0 || $0.isEmpty {
           self?.inputTextField.textState = .initial
         } else if (1...3).contains($0.count) {
@@ -122,11 +117,6 @@ extension MyInformationViewController: ViewBindCase {
           self?.inputTextField.textState = .overflow
           self?.inputNoticeLabel.textColor = .yg.red2
         }
-        /// 텍스트 이용 불가능하면 정지
-        if self?.inputTextField.textState != .available {
-          self?.storeLabel.isUserInteractionEnabled = false
-          self?.storeLabel.textColor = .yg.gray1
-        }
         self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
       }.store(in: &subscriptions)
   }
@@ -136,9 +126,13 @@ extension MyInformationViewController: ViewBindCase {
     case .none:
       break
     case .duplicatedNickname:
-      break
+      storeLabel.isUserInteractionEnabled = false
+      storeLabel.textColor = .yg.gray1
     case .availableNickname:
-      break
+      inputTextField.textState = .available
+      inputNoticeLabel.textColor = .yg.primary
+      storeLabel.isUserInteractionEnabled = true
+      storeLabel.textColor = .yg.primary
     }
   }
   

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -112,11 +112,13 @@ extension MyInformationViewController: ViewBindCase {
     case .duplicatedNickname:
       storeLabel.isUserInteractionEnabled = false
       storeLabel.textColor = .yg.gray1
+      inputNoticeLabel.text = inputTextField.textState.quotation
     case .availableNickname:
       inputTextField.textState = .available
       inputNoticeLabel.textColor = .yg.primary
       storeLabel.isUserInteractionEnabled = true
       storeLabel.textColor = .yg.primary
+      inputNoticeLabel.text = inputTextField.textState.quotation
     }
   }
   
@@ -134,7 +136,7 @@ private extension MyInformationViewController {
           self?.input.isDuplicatedUserName.send($0)
         } else if $0.count == 0 || $0.isEmpty {
           self?.inputTextField.textState = .initial
-        } else if (1...3).contains($0.count) {
+        } else if (1...2).contains($0.count) {
           /// 닉네임 글자 최소 넘지 못함.
           self?.inputTextField.textState = .underflow
           self?.inputNoticeLabel.textColor = .yg.red2
@@ -142,6 +144,10 @@ private extension MyInformationViewController {
           /// 닉네임 글자 넘음
           self?.inputTextField.textState = .overflow
           self?.inputNoticeLabel.textColor = .yg.red2
+        }
+        if self?.inputTextField.textState != .available {
+          self?.storeLabel.isUserInteractionEnabled = false
+          self?.storeLabel.textColor = .yg.gray1
         }
         self?.inputNoticeLabel.text = self?.inputTextField.textState.quotation
       }.store(in: &subscriptions)

--- a/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
+++ b/travelPlan/Source/Feature/Profile/ViewController/MyInformationViewController.swift
@@ -59,7 +59,18 @@ final class MyInformationViewController: UIViewController {
     $0.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTapStoreLabel)))
   }
   
+  private let viewModel: any MyInformationViewModelable
+  
   private var subscriptions = Set<AnyCancellable>()
+  
+  init(viewModel: any MyInformationViewModelable) {
+    self.viewModel = viewModel
+    super.init(nibName: nil, bundle: nil)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
   
   // MARK: - Lifecycle
   override func viewDidLoad() {
@@ -93,19 +104,25 @@ extension MyInformationViewController: ViewBindCase {
       .sink { [weak self] in
         if (3...15).contains($0.count) {
           // TODO: - 서버에 이 이름을 가진 유저가 있는지 체크 후 inputTextField 상태 변경해야합니다.
+          
+          /// 이용가능한 글인 경우 서버에 중복 여부 확인하기
           self?.inputTextField.textState = .available
           self?.inputNoticeLabel.textColor = .yg.primary
           self?.storeLabel.isUserInteractionEnabled = true
           self?.storeLabel.textColor = .yg.primary
+          
         } else if $0.count == 0 || $0.isEmpty {
           self?.inputTextField.textState = .initial
         } else if (1...3).contains($0.count) {
+          /// 닉네임 글자 최소 넘지 못함.
           self?.inputTextField.textState = .underflow
           self?.inputNoticeLabel.textColor = .yg.red2
         } else {
+          /// 닉네임 글자 넘음
           self?.inputTextField.textState = .overflow
           self?.inputNoticeLabel.textColor = .yg.red2
         }
+        /// 텍스트 이용 불가능하면 정지
         if self?.inputTextField.textState != .available {
           self?.storeLabel.isUserInteractionEnabled = false
           self?.storeLabel.textColor = .yg.gray1
@@ -117,6 +134,10 @@ extension MyInformationViewController: ViewBindCase {
   func render(_ state: MyInformationViewModel.State) {
     switch state {
     case .none:
+      break
+    case .duplicatedNickname:
+      break
+    case .availableNickname:
       break
     }
   }

--- a/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
+++ b/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
@@ -1,0 +1,19 @@
+//
+//  MyInformationViewModel.swift
+//  travelPlan
+//
+//  Created by 양승현 on 2/28/24.
+//
+
+import Foundation
+import Combine
+
+struct MyInformationViewModel {
+  struct Input {
+    let isDuplicatedUserName: PassthroughSubject<String, Never>
+  }
+  
+  enum State {
+    case none
+  }
+}

--- a/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
+++ b/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
@@ -15,5 +15,7 @@ struct MyInformationViewModel {
   
   enum State {
     case none
+    case duplicatedNickname
+    case availableNickname
   }
 }

--- a/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
+++ b/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
@@ -10,7 +10,7 @@ import Combine
 
 struct MyInformationViewModel {
   struct Input {
-    let isDuplicatedUserName: PassthroughSubject<String, Never>
+    let isDuplicatedUserName: PassthroughSubject<String, Never> = .init()
   }
   
   enum State {

--- a/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
+++ b/travelPlan/Source/Feature/Profile/ViewModel/MyInformationViewModel.swift
@@ -18,4 +18,23 @@ struct MyInformationViewModel {
     case duplicatedNickname
     case availableNickname
   }
+  
+  // MARK: - Dependencies
+  private let userInfoUseCase: UserInfoUseCase
+  
+  // MARK: - Properties
+  
+  // MARK: - Lifecycle
+  init(userInfoUseCase: UserInfoUseCase) {
+    self.userInfoUseCase = userInfoUseCase
+  }
+}
+
+// MARK: - MyInformationViewModelable
+extension MyInformationViewModel: MyInformationViewModelable {
+  func transform(_ input: Input) -> AnyPublisher<State, Never> {
+    return input.isDuplicatedUserName.map { _ in
+      return .none
+    }.eraseToAnyPublisher()
+  }
 }

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -270,6 +270,8 @@
 		15D655922B8E169100466FEC /* UserInfoUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D655912B8E169100466FEC /* UserInfoUseCaseTests.swift */; };
 		15D655952B8E17D400466FEC /* MockUserInfoRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D655942B8E17D400466FEC /* MockUserInfoRepository.swift */; };
 		15D6559A2B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D655992B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift */; };
+		15D6559D2B8F6F3800466FEC /* MyInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D6559C2B8F6F3800466FEC /* MyInformationViewModel.swift */; };
+		15D655A02B8F6F6300466FEC /* MyInformationViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D6559F2B8F6F6300466FEC /* MyInformationViewModelable.swift */; };
 		15D867CD2AD4003E00F35811 /* FavoriteViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D867CC2AD4003E00F35811 /* FavoriteViewModelable.swift */; };
 		15D867CF2AD427EC00F35811 /* FavoriteDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D867CE2AD427EC00F35811 /* FavoriteDetailCoordinator.swift */; };
 		15D955AD2ADEA525002BF9C3 /* FeedViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D955AC2ADEA525002BF9C3 /* FeedViewModelable.swift */; };
@@ -656,6 +658,8 @@
 		15D655912B8E169100466FEC /* UserInfoUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoUseCaseTests.swift; sourceTree = "<group>"; };
 		15D655942B8E17D400466FEC /* MockUserInfoRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserInfoRepository.swift; sourceTree = "<group>"; };
 		15D655992B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoAPIEndpointTests.swift; sourceTree = "<group>"; };
+		15D6559C2B8F6F3800466FEC /* MyInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInformationViewModel.swift; sourceTree = "<group>"; };
+		15D6559F2B8F6F6300466FEC /* MyInformationViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInformationViewModelable.swift; sourceTree = "<group>"; };
 		15D867CC2AD4003E00F35811 /* FavoriteViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewModelable.swift; sourceTree = "<group>"; };
 		15D867CE2AD427EC00F35811 /* FavoriteDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteDetailCoordinator.swift; sourceTree = "<group>"; };
 		15D955AC2ADEA525002BF9C3 /* FeedViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModelable.swift; sourceTree = "<group>"; };
@@ -1675,6 +1679,8 @@
 		15BED3032A0825BB00F86321 /* Profile */ = {
 			isa = PBXGroup;
 			children = (
+				15D6559E2B8F6F5600466FEC /* Protocol */,
+				15D6559B2B8F6F2000466FEC /* ViewModel */,
 				15C1F55D2AF3CD9E005FDA15 /* View */,
 				1503F9412A4E13FB002BC38D /* ViewController */,
 				1503F9322A4E0CFD002BC38D /* Coordinator */,
@@ -1796,6 +1802,22 @@
 				15D655992B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift */,
 			);
 			path = Tests;
+			sourceTree = "<group>";
+		};
+		15D6559B2B8F6F2000466FEC /* ViewModel */ = {
+			isa = PBXGroup;
+			children = (
+				15D6559C2B8F6F3800466FEC /* MyInformationViewModel.swift */,
+			);
+			path = ViewModel;
+			sourceTree = "<group>";
+		};
+		15D6559E2B8F6F5600466FEC /* Protocol */ = {
+			isa = PBXGroup;
+			children = (
+				15D6559F2B8F6F6300466FEC /* MyInformationViewModelable.swift */,
+			);
+			path = Protocol;
 			sourceTree = "<group>";
 		};
 		15DE36B72AB84FDC0030CCCC /* BottomSheet */ = {
@@ -2556,6 +2578,7 @@
 				15FEB5E52A050A99000A5F33 /* UIControl+Combine.swift in Sources */,
 				13C9C1AF2A17FFC400DF1FFF /* PostSearchHeaderViewDelegate.swift in Sources */,
 				15FFAC092AD7C1260013DB57 /* Requestable.swift in Sources */,
+				15D655A02B8F6F6300466FEC /* MyInformationViewModelable.swift in Sources */,
 				13A93EF72AD0AD2700FC4BBD /* SearchTopTenCell.swift in Sources */,
 				15D388232AFE75E100039946 /* PostDetailReplyCell.swift in Sources */,
 				13254FFB2A08AD8700094218 /* PostSearchViewController.swift in Sources */,
@@ -2597,6 +2620,7 @@
 				15C1F53C2AF27043005FDA15 /* NotificationViewAdapter.swift in Sources */,
 				1546DF302B0AF4C100B49A55 /* ImageMemoryCache.swift in Sources */,
 				15B928692AFA3F63003A20D4 /* PostDetailContentInfo.swift in Sources */,
+				15D6559D2B8F6F3800466FEC /* MyInformationViewModel.swift in Sources */,
 				151BDAD62B16EE07002F36C3 /* UIView+Combine.swift in Sources */,
 				13405F0B2AEEF1E400382796 /* LoginButtonDelegate.swift in Sources */,
 				15FFAC402ADE52120013DB57 /* MockPostUseCase.swift in Sources */,

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		15D6559A2B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D655992B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift */; };
 		15D6559D2B8F6F3800466FEC /* MyInformationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D6559C2B8F6F3800466FEC /* MyInformationViewModel.swift */; };
 		15D655A02B8F6F6300466FEC /* MyInformationViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D6559F2B8F6F6300466FEC /* MyInformationViewModelable.swift */; };
+		15D655A42B8F829800466FEC /* MyInformationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D655A32B8F829800466FEC /* MyInformationViewModelTests.swift */; };
 		15D867CD2AD4003E00F35811 /* FavoriteViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D867CC2AD4003E00F35811 /* FavoriteViewModelable.swift */; };
 		15D867CF2AD427EC00F35811 /* FavoriteDetailCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D867CE2AD427EC00F35811 /* FavoriteDetailCoordinator.swift */; };
 		15D955AD2ADEA525002BF9C3 /* FeedViewModelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15D955AC2ADEA525002BF9C3 /* FeedViewModelable.swift */; };
@@ -660,6 +661,7 @@
 		15D655992B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoAPIEndpointTests.swift; sourceTree = "<group>"; };
 		15D6559C2B8F6F3800466FEC /* MyInformationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInformationViewModel.swift; sourceTree = "<group>"; };
 		15D6559F2B8F6F6300466FEC /* MyInformationViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInformationViewModelable.swift; sourceTree = "<group>"; };
+		15D655A32B8F829800466FEC /* MyInformationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyInformationViewModelTests.swift; sourceTree = "<group>"; };
 		15D867CC2AD4003E00F35811 /* FavoriteViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewModelable.swift; sourceTree = "<group>"; };
 		15D867CE2AD427EC00F35811 /* FavoriteDetailCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteDetailCoordinator.swift; sourceTree = "<group>"; };
 		15D955AC2ADEA525002BF9C3 /* FeedViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedViewModelable.swift; sourceTree = "<group>"; };
@@ -1056,6 +1058,7 @@
 		151130072A04E4EB0041DDA1 /* travelPlanTests */ = {
 			isa = PBXGroup;
 			children = (
+				15D655A12B8F820100466FEC /* Presentation */,
 				151130082A04E4EB0041DDA1 /* travelPlanTests.swift */,
 			);
 			path = travelPlanTests;
@@ -1820,6 +1823,30 @@
 			path = Protocol;
 			sourceTree = "<group>";
 		};
+		15D655A12B8F820100466FEC /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				15D655A22B8F824C00466FEC /* Profile */,
+			);
+			path = Presentation;
+			sourceTree = "<group>";
+		};
+		15D655A22B8F824C00466FEC /* Profile */ = {
+			isa = PBXGroup;
+			children = (
+				15D655A52B8F848400466FEC /* Mock */,
+				15D655A32B8F829800466FEC /* MyInformationViewModelTests.swift */,
+			);
+			path = Profile;
+			sourceTree = "<group>";
+		};
+		15D655A52B8F848400466FEC /* Mock */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Mock;
+			sourceTree = "<group>";
+		};
 		15DE36B72AB84FDC0030CCCC /* BottomSheet */ = {
 			isa = PBXGroup;
 			children = (
@@ -2322,6 +2349,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				15D6559A2B8E1CCB00466FEC /* UserInfoAPIEndpointTests.swift in Sources */,
+				15D655A42B8F829800466FEC /* MyInformationViewModelTests.swift in Sources */,
 				15D655922B8E169100466FEC /* UserInfoUseCaseTests.swift in Sources */,
 				15FFAC2F2ADD03130013DB57 /* MockUserEndpoint.swift in Sources */,
 				1546DF3F2B0C64E500B49A55 /* ImageDiskCacheTests.swift in Sources */,

--- a/travelPlan/travelPlanTests/Presentation/Profile/MyInformationViewModelTests.swift
+++ b/travelPlan/travelPlanTests/Presentation/Profile/MyInformationViewModelTests.swift
@@ -1,0 +1,35 @@
+//
+//  MyInformationViewModelTests.swift
+//  travelPlanTests
+//
+//  Created by 양승현 on 2/29/24.
+//
+
+import XCTest
+
+final class MyInformationViewModelTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

<img src="https://github.com/IF-TG/iOS/assets/96910404/5ff47e3c-aa74-4658-a5ab-7b48c5a31ba4" width="250">|
|:-:|
|`사용자 닉네임 중복여부 담당 유즈케이스 호출`|

- 이전 <a href="https://github.com/IF-TG/iOS/pull/162">풀 리퀘스트</a>에서 userInfo Endpoint, notification Endpoint 싱글톤을 제거함에 따라 테스트케이스 전부 변경.

- MyInformationViewModel 일부 구현
- Presentation layer에 input, output적용
- 사용자 닉네임 변경시 중복 여부 UserInfoUseCase.isDuplicatedNickname(with:) Presentation layer에 적용
- 사용자 닉네임이 중복인지 아닌지 여부를 서버에 요청한 결과가 MyInformationViewModel의  transform(with:)에서 VC's state에 잘 나타나는지 단위 테스트
- MyInformationViewController 생성할 때 서버가 동작되지 않음으로 MockSession 주입