### PR TITLE
[Fix] Network module make request 객체 및 Endpoint 개선

### DIFF
--- a/travelPlan/Source/Core/Network/Module/Endpoint.swift
+++ b/travelPlan/Source/Core/Network/Module/Endpoint.swift
@@ -8,12 +8,10 @@
 import Alamofire
 
 final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Decodable {
-  
   // MARK: - Properties
   var scheme: String
   var host: String
   var method: HTTPMethod
-  var prefixPath: String
   var parameters: [ParameterType]?
   var requestType: RequestType
   var headers: HTTPHeaders?
@@ -24,7 +22,6 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     scheme: String = "https",
     host: String = "호스트 미정",
     method: HTTPMethod = .get,
-    prefixPath: String = "미정",
     parameters: [ParameterType]?,
     requestType: RequestType,
     headers: HTTPHeaders? = ["Content-Type": "application/json"],
@@ -33,7 +30,6 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     self.scheme = scheme
     self.host = host
     self.method = method
-    self.prefixPath = prefixPath
     self.parameters = parameters
     self.requestType = requestType
     self.headers = headers

--- a/travelPlan/Source/Core/Network/Module/Endpoint.swift
+++ b/travelPlan/Source/Core/Network/Module/Endpoint.swift
@@ -8,12 +8,13 @@
 import Alamofire
 
 final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Decodable {
+  
   // MARK: - Properties
   var scheme: String
   var host: String
   var method: HTTPMethod
   var prefixPath: String
-  var parameters: Encodable?
+  var parameters: [ParameterType]?
   var requestType: RequestType
   var headers: HTTPHeaders?
   var interceptor: RequestInterceptor?
@@ -24,7 +25,7 @@ final class Endpoint<ResponseDTO>: NetworkInteractionable where ResponseDTO: Dec
     host: String = "호스트 미정",
     method: HTTPMethod = .get,
     prefixPath: String = "미정",
-    parameters: Encodable?,
+    parameters: [ParameterType]?,
     requestType: RequestType,
     headers: HTTPHeaders? = ["Content-Type": "application/json"],
     interceptor: RequestInterceptor? = nil

--- a/travelPlan/Source/Core/Network/Module/ParameterType.swift
+++ b/travelPlan/Source/Core/Network/Module/ParameterType.swift
@@ -1,0 +1,13 @@
+//
+//  ParameterType.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/3/24.
+//
+
+import Foundation
+
+enum ParameterType {
+  case query(Encodable?)
+  case body(Encodable?)
+}

--- a/travelPlan/Source/Core/Network/Module/Requestable.swift
+++ b/travelPlan/Source/Core/Network/Module/Requestable.swift
@@ -6,15 +6,16 @@
 //
 
 import Alamofire
+import Foundation
 
 protocol Requestable {
   typealias Error = AFError
   var scheme: String { get }
   var host: String { get }
   var method: HTTPMethod { get }
-  var prefixPath: String { get }
   /// get일땐 queryItems에 부착, post일때 httpbody에 추가.
-  var parameters: Encodable? { get }
+  /// 하지만 서버 명세서에 따라서, 서버에 요청할 때 두 개의 파라미터 사용하는 경우가 있습니다.
+  var parameters: [ParameterType]? { get }
   var requestType: RequestType { get }
   var headers: HTTPHeaders? { get }
   var interceptor: RequestInterceptor? { get }
@@ -22,7 +23,7 @@ protocol Requestable {
 
 extension Requestable {
   var baseURL: String {
-    "\(scheme)://\(host)" + prefixPath
+    "\(scheme)://\(host)"
   }
   
   var baseURLWithRequestPath: String {
@@ -30,10 +31,45 @@ extension Requestable {
   }
   
   func makeRequest(from session: Session) throws -> DataRequest {
+    /// HTTPMETHOD == post임에도 query, body param 둘 다 담아서 보내야 하는 경우
+    if parameters?.count == 2 {
+      return try makeRequestWhenParametersHave(from: session)
+    }
+    
+    /// 일반적으로 서버에 보내야 할 Parameters 개수가 한개인 경우입니다.
+    var requestDTO: Encodable?
+    if let hasParameter = parameters?.first {
+      if case .query(let encodable) = hasParameter { requestDTO = encodable }
+      if case .body(let encodable) = hasParameter { requestDTO = encodable }
+    }
     return session.request(
       baseURLWithRequestPath,
       method: method,
-      parameters: parameters?.toDictionary,
+      parameters: requestDTO?.toDictionary,
+      interceptor: interceptor)
+  }
+  
+  private func makeRequestWhenParametersHave(from session: Session) throws -> DataRequest {
+    guard var urlComponents = URLComponents(string: baseURLWithRequestPath) else {
+      throw ReferenceError.other("URLComponents가 만들어지지 않음.")
+    }
+    var bodyParam: Encodable?
+    guard let parameters else { throw ReferenceError.other("makeRequest의 parameter존재하지 않음") }
+    for parameter in parameters {
+      if case .query(let encodable) = parameter {
+        if let dict = encodable?.toDictionary {
+          let queryItems = dict.map { URLQueryItem(name: $0, value: "\($1)")}
+          urlComponents.queryItems = queryItems
+        }
+      }
+      if case .body(let encodable) = parameter {
+        bodyParam = encodable
+      }
+    }
+    return session.request(
+      urlComponents,
+      method: method,
+      parameters: bodyParam?.toDictionary,
       interceptor: interceptor)
   }
 }

--- a/travelPlan/Source/Core/Network/Tests/EndpointTests.swift
+++ b/travelPlan/Source/Core/Network/Tests/EndpointTests.swift
@@ -99,6 +99,7 @@ extension EndpointTests {
     wait(for: [expectation], timeout: 10)
   }
   
+  /// ex) body Parameter :  { profile: String }  + query Parameter : { userId :  long  } 이 두개가 한 요청에 url에 담겨야 할 경우에 대한 테스트입니다.
   func testEndPoint_makeRequest할때_두개의Parameters가_사용될_경우_AbsoluteURL이_잘_만들어지는지_shouldReturnEqaul() {
     // Arrange
     // 이 객체가 url의 query param에 담겨야 합니다.
@@ -130,5 +131,40 @@ extension EndpointTests {
     XCTAssertNotNil(dataRequest?.convertible.urlRequest, "DataRequest의 urlRequest를 반환해야하는데 nil반환")
     XCTAssertEqual(
       dataRequest?.convertible.urlRequest?.url, targetURL)
+  }
+  
+  /// ex) body Parameter :  { profile: String }  + query Parameter : { userId :  long  } 이 두개가 한 요청에 url에 담겨야 할 경우에 대한 테스트입니다.
+  func testEndPoint_makeRequest할때_두개의Parameters가_사용될_경우_bodyParam이_httpBody에_잘_추가되는지_shouldReturnEqual() {
+    // Arrange
+    // 이 객체가 url의 query param에 담겨야 합니다.
+    struct TempQueryParameterReqeustDTO: Encodable {
+      // 만약 사용자 액세스 토큰을 HTTP header말고 query param에 같이 보내야 한다면?
+      let accessToken: String
+    }
+    
+    let mockReqeustQueryParamDTO = TempQueryParameterReqeustDTO(accessToken: "ab1@2")
+    mockRequestModel = UserNameRequestDTO(name: "nice", id: 777)
+    let expectedJsonString = "id=\(mockRequestModel.id)&name=\(mockRequestModel.name)"
+    sut = Endpoint(
+      scheme: "http",
+      host: "test.com",
+      method: .post,
+      parameters: [.query(mockReqeustQueryParamDTO), .body(mockRequestModel)],
+      requestType: .custom("user/name-update"))
+    var dataRequest: DataRequest?
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? sut.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "DataRequest를 반환해야하는데 nil반환")
+    XCTAssertNotNil(dataRequest?.convertible.urlRequest?.httpBody, "httpBody에 값이 담겨야 하는데 nil 반환")
+    let testData = dataRequest!.convertible.urlRequest!.httpBody!
+    let testString = String(data: testData, encoding: .utf8) ?? "no"
+    XCTAssertEqual(testString, expectedJsonString)
   }
 }

--- a/travelPlan/Source/Core/Network/Tests/EndpointTests.swift
+++ b/travelPlan/Source/Core/Network/Tests/EndpointTests.swift
@@ -23,9 +23,8 @@ final class EndpointTests: XCTestCase {
       scheme: "http",
       host: "test.com",
       method: .get,
-      prefixPath: "/user",
-      parameters: mockRequestModel,
-      requestType: .custom("name-update"))
+      parameters: [.query(mockRequestModel)],
+      requestType: .custom("user/name-update"))
     MockUrlProtocol.requestHandler = { _ in
       return ((HTTPURLResponse(), Data()))
     }

--- a/travelPlan/Source/Core/Network/Tests/Mocks/MockUserEndpoint.swift
+++ b/travelPlan/Source/Core/Network/Tests/Mocks/MockUserEndpoint.swift
@@ -18,8 +18,7 @@ final class MockUserEndpoint {
       scheme: "https",
       host: "test.com",
       method: .post,
-      prefixPath: "/user",
-      parameters: requestDTO,
+      parameters: [.query(requestDTO)],
       requestType: .custom("name-update"))
   }
 }

--- a/travelPlan/Source/Data/Network/NotificationAPIEndpoints.swift
+++ b/travelPlan/Source/Data/Network/NotificationAPIEndpoints.swift
@@ -11,7 +11,6 @@ struct NotificationAPIEndpoints {
   static func fetchNotices() -> Endpoint<[NoticeResponseDTO]> {
     return Endpoint<[NoticeResponseDTO]>(
       host: "v1/", 
-      prefixPath: "temp",
       parameters: nil,
       requestType: .none)
   }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -16,7 +16,6 @@ struct UserInfoAPIEndpoint {
       scheme: "http",
       host: "localhost:8080",
       method: .get,
-      prefixPath: "",
       parameters: [.query(requestDTO)],
       requestType: .userNameDuplicateCheck)
   }
@@ -27,7 +26,6 @@ struct UserInfoAPIEndpoint {
     return Endpoint<CommonDTO<Bool>>(
     scheme: "http",
     host: "localhost:8080",
-    prefixPath: "",
     parameters: [.query(requestDTO)],
     requestType: .userNameDuplicateCheck)
   }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -17,7 +17,7 @@ struct UserInfoAPIEndpoint {
       host: "localhost:8080",
       method: .get,
       prefixPath: "",
-      parameters: requestDTO,
+      parameters: [.query(requestDTO)],
       requestType: .userNameDuplicateCheck)
   }
   
@@ -28,7 +28,7 @@ struct UserInfoAPIEndpoint {
     scheme: "http",
     host: "localhost:8080",
     prefixPath: "",
-    parameters: requestDTO,
+    parameters: [.query(requestDTO)],
     requestType: .userNameDuplicateCheck)
   }
 }

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		152AD5272A1B89D2008A2A11 /* FavoriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */; };
 		152AD52A2A1B8D6E008A2A11 /* MockFavoriteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */; };
 		153841D72A5642A9004C41D1 /* PostViewBottomSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */; };
+		153FA9112B938C19006CF3C3 /* ParameterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153FA9102B938C19006CF3C3 /* ParameterType.swift */; };
 		1546DF242B0A70C900B49A55 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF232B0A70C900B49A55 /* Cache.swift */; };
 		1546DF282B0A7CE400B49A55 /* Cache+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF272B0A7CE400B49A55 /* Cache+Nested.swift */; };
 		1546DF302B0AF4C100B49A55 /* ImageMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF2F2B0AF4C100B49A55 /* ImageMemoryCache.swift */; };
@@ -532,6 +533,7 @@
 		152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewModel.swift; sourceTree = "<group>"; };
 		152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFavoriteUseCase.swift; sourceTree = "<group>"; };
 		153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewBottomSheetCell.swift; sourceTree = "<group>"; };
+		153FA9102B938C19006CF3C3 /* ParameterType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParameterType.swift; sourceTree = "<group>"; };
 		1546DF232B0A70C900B49A55 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		1546DF272B0A7CE400B49A55 /* Cache+Nested.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cache+Nested.swift"; sourceTree = "<group>"; };
 		1546DF2F2B0AF4C100B49A55 /* ImageMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMemoryCache.swift; sourceTree = "<group>"; };
@@ -1202,9 +1204,9 @@
 		151DF0FF2AEEBC0700D5D55B /* Network */ = {
 			isa = PBXGroup;
 			children = (
-				15D655962B8E1C6900466FEC /* Tests */,
 				15D655852B8E0A5A00466FEC /* RequestDTO */,
 				151DF1022AEEBDE100D5D55B /* ResponseDTO */,
+				15D655962B8E1C6900466FEC /* Tests */,
 				151DF1002AEEBD0A00D5D55B /* NotificationAPIEndpoints.swift */,
 				15D655812B8E079200466FEC /* UserInfoAPIEndpoint.swift */,
 			);
@@ -2077,6 +2079,7 @@
 				15FFAC142ADA83E00013DB57 /* SessionProvider.swift */,
 				15FFAC102AD9C7A10013DB57 /* Sessionable.swift */,
 				15FFAC062AD6ED5B0013DB57 /* Endpoint.swift */,
+				153FA9102B938C19006CF3C3 /* ParameterType.swift */,
 			);
 			path = Module;
 			sourceTree = "<group>";
@@ -2705,6 +2708,7 @@
 				15FB47EE2AC176FD0033AA18 /* UISpacing.swift in Sources */,
 				15CB236F2A10C314003EAF20 /* PostCellViewModel.swift in Sources */,
 				13C9C1B12A1806F500DF1FFF /* PostRecentSearchTagCellDelegate.swift in Sources */,
+				153FA9112B938C19006CF3C3 /* ParameterType.swift in Sources */,
 				15FFAC0D2AD9AEB80013DB57 /* Encodable+.swift in Sources */,
 				15FFAC132AD9C7EB0013DB57 /* NetwrokInteractionable.swift in Sources */,
 				13405F662AF4470200382796 /* ReviewWritingViewController.swift in Sources */,


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- Endpoint parameters 타입 변경, makeRequest 개선
- 기존에 Endpoint parameters에 encodable 타입을 넣을 때 배열안에 ParameterType의 associated value에 넣어야 합니다.
- prefixPath 제거.
   - prefixPath를 차라리 RequsetType에 enum으로 선언해서 만드는 것도 좋은 방법일 것 같다는 생각이 들었습니다. (매번 string으로 구별해서 입력하는것은 더 번거로울 것 같기도 합니다..)

---

일반적으로 서버에 요청할 때 보낼 데이터로 requesetDTO와 httpMethod를 설정해 Endpoint 객체를 구현합니다. 이때 자동으로 httpMethod에 따라서 url의 query로 담길 것인지 body parameter로 정보가 담길 것인지 자동으로 결정합니다.


<img width="354" alt="image" src="https://github.com/IF-TG/iOS/assets/96910404/55bfb394-6bc7-4b24-bd33-4d2be9a07384">

위와 같이 특정 서버 호출 명세서에는 2개의 paramters가 동시에 담겨서 서버에 전송되야 합니다. 기존의 Endoint는 단순 HttpMehtod에 따라서 담기는 것이므로 .post 인 경우 Endpoint에 주입한 requestDTO가 body parameter에 담깁니다. 이때 특정한 정보만 url query parameter로 담길 순 없었습니다. 그래서 리빌딩했습니다.

---

Endpoint의 parameters타입을 ParameterType으로 변경했습니다. 

<img width="342" alt="image" src="https://github.com/IF-TG/iOS/assets/96910404/84992c6b-f620-431f-9581-21e25e6eb58e">

그래서 이제 서버에 호출할 때 http method 타입 지정 후 parameter를 넣지 않거나, 배열 안에 한개의 enum타입을 넣으면 됩니다. ( 배열로 감싸기만 하면 됩니다. )

서버 호출시 필요한 parameter가 하나라면
post일땐 body, get일 땐 query를 생각해서 해당 타입과 associated value를 넣으면 되는데, 사실 타입이 1개일때는 post, get 어느것을 사용하든 내부에 httpMethod에 따라 자동으로 처리할 수 있도록 반영했습니다.

일반적으로 EndpointTests에서 setup에 sut에 생성된 Endpoint를 통해 사용 방법 확인할 수 있습니다.
--- 
주의할 것은  paraneters타입이 2개인 경우입니다.
<img width="349" alt="image" src="https://github.com/IF-TG/iOS/assets/96910404/2851f748-6e57-4fbf-82ac-729adb010e48">

이땐 httpMethod타입과 query, body에 담길 각각의 parameters를 Endpoint's parameters에 넣어주어야 합니다.
위와 같은 경우 query에는 userId만 담기기 때문에 이를 유의해서 requset해야합니다....

그 예로 
- testEndPoint_makeRequest할때_두개의Parameters가_사용될_경우_AbsoluteURL이_잘_만들어지는지_shouldReturnEqaul()
- testEndPoint_makeRequest할때_두개의Parameters가_사용될_경우_bodyParam이_httpBody에_잘_추가되는지_shouldReturnEqual()

이 두 테스트를 통해 Endpoint에 값을 어떻게 넣어야 하는지 알 수 있습니다: ]
