### PR TITLE
[Feature] 사용자 프로필 업데이트, 삭제, 저장, 받기에 관해 Domain, Data layer 구현했습니다.

### DIFF
--- a/travelPlan/.swiftlint.yml
+++ b/travelPlan/.swiftlint.yml
@@ -1,5 +1,6 @@
 excluded:
     - Pods
+    - "**/*Tests.swift"
     - Libraries
     - travelPlanTests/
     - travelPlanUITests/

--- a/travelPlan/Source/Core/Network/Module/RequestType.swift
+++ b/travelPlan/Source/Core/Network/Module/RequestType.swift
@@ -15,6 +15,7 @@ enum RequestType {
   case userProfileUpdate
   case userProfileSave
   case userProfileDelete
+  case userProfileFetch
   
   var path: String {
     switch self {
@@ -28,6 +29,8 @@ enum RequestType {
       return "profile/upload"
     case .userProfileDelete:
       return "profile"
+    case .userProfileFetch:
+      return "profile/original"
     case .custom(let requestPath):
       return requestPath
     }

--- a/travelPlan/Source/Core/Network/Module/RequestType.swift
+++ b/travelPlan/Source/Core/Network/Module/RequestType.swift
@@ -14,6 +14,7 @@ enum RequestType {
   case custom(String)
   case userProfileUpdate
   case userProfileSave
+  case userProfileDelete
   
   var path: String {
     switch self {
@@ -25,6 +26,8 @@ enum RequestType {
       return "profile/upload"
     case .userProfileSave:
       return "profile/upload"
+    case .userProfileDelete:
+      return "profile"
     case .custom(let requestPath):
       return requestPath
     }

--- a/travelPlan/Source/Core/Network/Module/RequestType.swift
+++ b/travelPlan/Source/Core/Network/Module/RequestType.swift
@@ -13,6 +13,7 @@ enum RequestType {
   case userNameDuplicateCheck
   case custom(String)
   case userProfileUpdate
+  case userProfileSave
   
   var path: String {
     switch self {
@@ -21,6 +22,8 @@ enum RequestType {
     case .userNameDuplicateCheck:
       return "nickname"
     case .userProfileUpdate:
+      return "profile/upload"
+    case .userProfileSave:
       return "profile/upload"
     case .custom(let requestPath):
       return requestPath

--- a/travelPlan/Source/Core/Network/Module/RequestType.swift
+++ b/travelPlan/Source/Core/Network/Module/RequestType.swift
@@ -12,6 +12,7 @@ enum RequestType {
   /// 사용자 이름 중복 체크와 사용자 이름 업데이트 두 개의 로직에서 사용중
   case userNameDuplicateCheck
   case custom(String)
+  case userProfileUpdate
   
   var path: String {
     switch self {
@@ -19,6 +20,8 @@ enum RequestType {
       return ""
     case .userNameDuplicateCheck:
       return "nickname"
+    case .userProfileUpdate:
+      return "upload"
     case .custom(let requestPath):
       return requestPath
     }

--- a/travelPlan/Source/Data/Network/RequestDTO/UserIdReqeustDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserIdReqeustDTO.swift
@@ -1,0 +1,12 @@
+//
+//  UserIdReqeustDTO.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/4/24.
+//
+
+import Foundation
+
+struct UserIdReqeustDTO: Encodable {
+  let userId: Int64
+}

--- a/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
@@ -9,4 +9,5 @@ import Foundation
 
 struct UserProfileRequestDTO: Encodable {
   let profile: String
+  let userID: Int
 }

--- a/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
@@ -1,0 +1,8 @@
+//
+//  UserProfileRequestDTO.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/3/24.
+//
+
+import Foundation

--- a/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
@@ -7,6 +7,6 @@
 
 import Foundation
 
-struct UserProfileRequestDTO: Decodable {
+struct UserProfileRequestDTO: Encodable {
   let profile: String
 }

--- a/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
@@ -6,3 +6,7 @@
 //
 
 import Foundation
+
+struct UserProfileRequestDTO: Decodable {
+  let profile: String
+}

--- a/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
+++ b/travelPlan/Source/Data/Network/RequestDTO/UserProfileRequestDTO.swift
@@ -9,5 +9,4 @@ import Foundation
 
 struct UserProfileRequestDTO: Encodable {
   let profile: String
-  let userID: Int
 }

--- a/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
+++ b/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct UserProfileResponseDTO: Decodable {
   let imageURL: String
-  let userID: String
+  let userID: Int64
   
   enum CodingKeys: String, CodingKey {
     case imageURL = "imageUrl"
@@ -19,7 +19,7 @@ struct UserProfileResponseDTO: Decodable {
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     self.imageURL = try container.decode(String.self, forKey: .imageURL)
-    self.userID = try container.decode(String.self, forKey: .userID)
+    self.userID = try container.decode(Int64.self, forKey: .userID)
   }
 }
 

--- a/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
+++ b/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
@@ -6,3 +6,19 @@
 //
 
 import Foundation
+
+struct UserProfileResponseDTO: Decodable {
+  let imageURL: String
+  let userID: String
+  
+  enum CodingKeys: String, CodingKey {
+    case imageURL = "imageUrl"
+    case userID = "userId"
+  }
+  
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.imageURL = try container.decode(String.self, forKey: .imageURL)
+    self.userID = try container.decode(String.self, forKey: .userID)
+  }
+}

--- a/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
+++ b/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
@@ -22,3 +22,10 @@ struct UserProfileResponseDTO: Decodable {
     self.userID = try container.decode(String.self, forKey: .userID)
   }
 }
+
+// MARK: - Mappings to Domain
+extension UserProfileResponseDTO {
+  func toDomain() -> ProfileImageEntity {
+    return .init(image: imageURL)
+  }
+}

--- a/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
+++ b/travelPlan/Source/Data/Network/ResponseDTO/UserProfileResponseDTO.swift
@@ -1,0 +1,8 @@
+//
+//  UserProfileResponseDTO.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/3/24.
+//
+
+import Foundation

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -6,6 +6,7 @@
 //
 
 import XCTest
+import Alamofire
 @testable import travelPlan
 
 final class UserInfoAPIEndpointTests: XCTestCase {
@@ -66,5 +67,28 @@ final class UserInfoAPIEndpointTests: XCTestCase {
       expectation.fulfill()
     }
     wait(for: [expectation], timeout: 10)
+  }
+  
+  func testUserInfoAPIEndpoint_UpdateProfile함수를_통해_makeRequest함수_호출할때_AbsoluteURL이_정확한지_ShouldReturnEqual() {
+    // Arrange
+    let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
+    let requestDTO = UserProfileRequestDTO(profile: "test1234", userID: 13)
+    let endpoint = sut.updateProfile(with: requestDTO)
+    var dataRequest: DataRequest?
+    expectation = expectation(description: "UpdatePRofile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(
+      dataRequest?.convertible.urlRequest,
+      "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
   }
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -38,10 +38,10 @@ final class UserInfoAPIEndpointTests: XCTestCase {
       let dataRequest = try? userNicknameEndpoint.makeRequest(from: mockSession)
       
       // Assert
-      XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 checkIfNicknameDuplicate()에서 DataRequest를 반환해야 하는데 nil 반환")
+      XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 checkIfNicknameDuplicate()에서 DataRequest를 반환해야 하는데 nil 반환")
       XCTAssertNotNil(
         dataRequest?.convertible.urlRequest,
-        "UserIfnoAPIEndpoint의 checkIfNicknameDuplicate()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+        "UserInfoAPIEndpoint의 checkIfNicknameDuplicate()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
       XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
       expectation.fulfill()
     }
@@ -59,10 +59,10 @@ final class UserInfoAPIEndpointTests: XCTestCase {
       let dataRequest = try? endpoint.makeRequest(from: mockSession)
       
       // Assert
-      XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest를 반환해야 하는데 nil 반환")
+      XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 updateUserNickname()에서 DataRequest를 반환해야 하는데 nil 반환")
       XCTAssertNotNil(
         dataRequest?.convertible.urlRequest,
-        "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+        "UserInfoAPIEndpoint의 updateUserNickname()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
       XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
       expectation.fulfill()
     }
@@ -76,7 +76,7 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     let requestDTO = UserProfileRequestDTO(profile: "test1234")
     let endpoint = sut.updateProfile(withQuery: queryRequestDTO, body: requestDTO)
     var dataRequest: DataRequest?
-    expectation = expectation(description: "UpdatePRofile finish")
+    expectation = expectation(description: "UpdateProfile finish")
     
     // Act
     DispatchQueue.global().async { [unowned self] in
@@ -86,10 +86,10 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     wait(for: [expectation], timeout: 10)
     
     // Assert
-    XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
     XCTAssertNotNil(
       dataRequest?.convertible.urlRequest,
-      "UserIfnoAPIEndpoint의 updatePRofile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+      "UserInfoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
     XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
   }
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -120,4 +120,57 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
     XCTAssertEqual(testString, expectedJsonString)
   }
+  
+  func testUserInfoAPIEndpoint_SaveProfile함수를_통해_makeRequest함수_호출할때_AbsoluteURL이_정확한지_ShouldReturnSuccess() {
+    // Arrange
+    let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
+    let queryRequestDTO = UserIdReqeustDTO(userId: 13)
+    let requestDTO = UserProfileRequestDTO(profile: "test1234")
+    let endpoint = sut.saveProfile(withQuery: queryRequestDTO, body: requestDTO)
+    var dataRequest: DataRequest?
+    expectation = expectation(description: "saveProfile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 saveProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(
+      dataRequest?.convertible.urlRequest,
+      "UserInfoAPIEndpoint의 saveProfile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
+  }
+  
+  func testUserInfoAPIEndpoint_SaveProfile함수를_통해_makeRequest함수_호출할때_bodyParam이_잘추가되었는지_ShouldReturnEqual() {
+    // Arrange
+    let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
+    let queryRequestDTO = UserIdReqeustDTO(userId: 13)
+    let requestDTO = UserProfileRequestDTO(profile: "test1234")
+    let endpoint = sut.updateProfile(withQuery: queryRequestDTO, body: requestDTO)
+    var dataRequest: DataRequest?
+    let expectedJsonString = "profile=test1234"
+    expectation = expectation(description: "saveProfile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 saveProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(
+      dataRequest?.convertible.urlRequest,
+      "UserInfoAPIEndpoint의 saveProfile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    let testData = dataRequest!.convertible.urlRequest!.httpBody!
+    let testString = String(data: testData, encoding: .utf8) ?? "no"
+    XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
+    XCTAssertEqual(testString, expectedJsonString)
+  }
+
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -196,4 +196,27 @@ final class UserInfoAPIEndpointTests: XCTestCase {
       "UserInfoAPIEndpoint의 deleteProfile(with:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
     XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
   }
+  
+  func testUserInfoAPIEndopint_fetchProfile함수를_통해_makeRequest함수_호출할때_AbsoluteURL이_정확한지_ShouldReturnEqual() {
+    // Arrange
+    let expectedURL = URL(string: "http://localhost:8080/profile/original?userId=13")
+    let mockRequestDTO = UserIdReqeustDTO(userId: 13)
+    let endpoint = sut.fetchProfile(with: mockRequestDTO)
+    var dataRequest: DataRequest?
+    expectation = expectation(description: "saveProfile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    let resultURL = dataRequest?.convertible.urlRequest?.url
+    XCTAssertNotNil(
+      resultURL,
+      "UserInfoAPIEndpoint의 fetchProfile(with:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    XCTAssertEqual(resultURL, expectedURL)
+  }
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -86,10 +86,10 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     wait(for: [expectation], timeout: 10)
     
     // Assert
-    XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(dataRequest, "UserIfnoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
     XCTAssertNotNil(
       dataRequest?.convertible.urlRequest,
-      "UserIfnoAPIEndpoint의 updateUserNickname()에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+      "UserIfnoAPIEndpoint의 updatePRofile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
     XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
   }
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -92,4 +92,32 @@ final class UserInfoAPIEndpointTests: XCTestCase {
       "UserInfoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
     XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
   }
+  
+  func testUserInfoAPIEndpoint_UpdateProfile함수를_통해_makeRequest함수_호출할때_bodyParam이_잘추가되었는지_ShouldReturnEqual() {
+    // Arrange
+    let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
+    let queryRequestDTO = UserIdReqeustDTO(userId: 13)
+    let requestDTO = UserProfileRequestDTO(profile: "test1234")
+    let endpoint = sut.updateProfile(withQuery: queryRequestDTO, body: requestDTO)
+    var dataRequest: DataRequest?
+    let expectedJsonString = "profile=test1234"
+    expectation = expectation(description: "UpdatePRofile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(
+      dataRequest?.convertible.urlRequest,
+      "UserInfoAPIEndpoint의 updateProfile(withQuery:body:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    let testData = dataRequest!.convertible.urlRequest!.httpBody!
+    let testString = String(data: testData, encoding: .utf8) ?? "no"
+    XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
+    XCTAssertEqual(testString, expectedJsonString)
+  }
 }

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -72,8 +72,9 @@ final class UserInfoAPIEndpointTests: XCTestCase {
   func testUserInfoAPIEndpoint_UpdateProfile함수를_통해_makeRequest함수_호출할때_AbsoluteURL이_정확한지_ShouldReturnEqual() {
     // Arrange
     let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
-    let requestDTO = UserProfileRequestDTO(profile: "test1234", userID: 13)
-    let endpoint = sut.updateProfile(with: requestDTO)
+    let queryRequestDTO = UserIdReqeustDTO(userId: 13)
+    let requestDTO = UserProfileRequestDTO(profile: "test1234")
+    let endpoint = sut.updateProfile(withQuery: queryRequestDTO, body: requestDTO)
     var dataRequest: DataRequest?
     expectation = expectation(description: "UpdatePRofile finish")
     

--- a/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
+++ b/travelPlan/Source/Data/Network/Tests/UserInfoAPIEndpointTests.swift
@@ -150,7 +150,7 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     let targetURL = URL(string: "http://localhost:8080/profile/upload?userId=13")
     let queryRequestDTO = UserIdReqeustDTO(userId: 13)
     let requestDTO = UserProfileRequestDTO(profile: "test1234")
-    let endpoint = sut.updateProfile(withQuery: queryRequestDTO, body: requestDTO)
+    let endpoint = sut.saveProfile(withQuery: queryRequestDTO, body: requestDTO)
     var dataRequest: DataRequest?
     let expectedJsonString = "profile=test1234"
     expectation = expectation(description: "saveProfile finish")
@@ -173,4 +173,27 @@ final class UserInfoAPIEndpointTests: XCTestCase {
     XCTAssertEqual(testString, expectedJsonString)
   }
 
+  func testUserInfoAPIEndpiont_DeleteProfile함수를_통해_makeRequest함수_호출할때_AbsoluteURL이_정확한지_ShouldReturnEqual() {
+    // Arrange
+    let targetURL = URL(string: "http://localhost:8080/profile?userId=13")
+    let mockRequestDTO = UserIdReqeustDTO(userId: 13)
+    let endpoint = sut.deleteProfile(with: mockRequestDTO)
+    var dataRequest: DataRequest?
+    let expectedJsonString = "profile=test1234"
+    expectation = expectation(description: "saveProfile finish")
+    
+    // Act
+    DispatchQueue.global().async { [unowned self] in
+      dataRequest = try? endpoint.makeRequest(from: mockSession)
+      expectation.fulfill()
+    }
+    wait(for: [expectation], timeout: 10)
+    
+    // Assert
+    XCTAssertNotNil(dataRequest, "UserInfoAPIEndpoint의 deleteProfile(with:)에서 DataRequest를 반환해야 하는데 nil 반환")
+    XCTAssertNotNil(
+      dataRequest?.convertible.urlRequest,
+      "UserInfoAPIEndpoint의 deleteProfile(with:)에서 DataRequest의 urlRequest를 반환해야하는데 nil 반환")
+    XCTAssertEqual(dataRequest?.convertible.urlRequest?.url, targetURL)
+  }
 }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -31,13 +31,14 @@ struct UserInfoAPIEndpoint {
   }
   
   static func updateProfile(
-    with requestDTO: UserProfileRequestDTO
+    withQuery queryRequestDTO: UserIdReqeustDTO,
+    body bodyReqeustDTO: UserProfileRequestDTO
   ) -> Endpoint<CommonDTO<UserProfileResponseDTO>> {
     return Endpoint<CommonDTO<UserProfileResponseDTO>>(
       scheme: "http",
       host: "localhost:8080",
       method: .post,
-      parameters: [.body(requestDTO)],
+      parameters: [.query(queryRequestDTO), .body(bodyReqeustDTO)],
       requestType: .userProfileUpdate)
   }
 }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -32,6 +32,7 @@ struct UserInfoAPIEndpoint {
 }
 
 /// About profile CRUD
+/// 이미 디비에 존재하는 프로필에 save호출 시 서버에 중복 저장 될 수 있습니다.
 extension UserInfoAPIEndpoint {
   static func updateProfile(
     withQuery queryRequestDTO: UserIdReqeustDTO,
@@ -43,5 +44,17 @@ extension UserInfoAPIEndpoint {
       method: .put,
       parameters: [.query(queryRequestDTO), .body(bodyReqeustDTO)],
       requestType: .userProfileUpdate)
+  }
+  
+  static func saveProfile(
+    withQuery queryReqeustDTO: UserIdReqeustDTO,
+    body bodyReqeustDTO: UserProfileRequestDTO
+  ) -> Endpoint<CommonDTO<UserProfileResponseDTO>> {
+    return Endpoint<CommonDTO<UserProfileResponseDTO>>(
+      scheme: "http",
+      host: "localhost:8080",
+      method: .post,
+      parameters: [.query(queryReqeustDTO), .body(bodyReqeustDTO)],
+      requestType: .userProfileSave)
   }
 }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -39,7 +39,7 @@ struct UserInfoAPIEndpoint {
     return Endpoint<CommonDTO<UserProfileResponseDTO>>(
       scheme: "http",
       host: "localhost:8080",
-      method: .put,
+      method: .post,
       prefixPath: prefixPath,
       parameters: requestDTO,
       requestType: .userProfileUpdate)

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -68,4 +68,15 @@ extension UserInfoAPIEndpoint {
       parameters: [.query(requestDTO)],
       requestType: .userProfileDelete)
   }
+  
+  static func fetchProfile(
+    with requestDTO: UserIdReqeustDTO
+  ) -> Endpoint<CommonDTO<UserProfileResponseDTO>> {
+    return Endpoint<CommonDTO<UserProfileResponseDTO>>(
+      scheme: "http",
+      host: "localhost:8080",
+      method: .get,
+      parameters: [.query(requestDTO)],
+      requestType: .userProfileFetch)
+  }
 }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -29,7 +29,10 @@ struct UserInfoAPIEndpoint {
     parameters: [.query(requestDTO)],
     requestType: .userNameDuplicateCheck)
   }
-  
+}
+
+/// About profile CRUD
+extension UserInfoAPIEndpoint {
   static func updateProfile(
     withQuery queryRequestDTO: UserIdReqeustDTO,
     body bodyReqeustDTO: UserProfileRequestDTO
@@ -37,7 +40,7 @@ struct UserInfoAPIEndpoint {
     return Endpoint<CommonDTO<UserProfileResponseDTO>>(
       scheme: "http",
       host: "localhost:8080",
-      method: .post,
+      method: .put,
       parameters: [.query(queryRequestDTO), .body(bodyReqeustDTO)],
       requestType: .userProfileUpdate)
   }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -8,6 +8,7 @@
 import Foundation
 
 struct UserInfoAPIEndpoint {
+  private static let prefixPath = "profile"
   /// 사용자의 이름이 중복인지 확인할 때 사용합니다.
   static func checkIfNicknameDuplicate(
     with requestDTO: UserNicknameRequestDTO
@@ -30,5 +31,17 @@ struct UserInfoAPIEndpoint {
     prefixPath: "",
     parameters: requestDTO,
     requestType: .userNameDuplicateCheck)
+  }
+  
+  static func updateProfile(
+    with requestDTO: UserProfileRequestDTO
+  ) -> Endpoint<CommonDTO<UserProfileResponseDTO>> {
+    return Endpoint<CommonDTO<UserProfileResponseDTO>>(
+      scheme: "http",
+      host: "localhost:8080",
+      method: .put,
+      prefixPath: prefixPath,
+      parameters: requestDTO,
+      requestType: .userProfileUpdate)
   }
 }

--- a/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
+++ b/travelPlan/Source/Data/Network/UserInfoAPIEndpoint.swift
@@ -57,4 +57,15 @@ extension UserInfoAPIEndpoint {
       parameters: [.query(queryReqeustDTO), .body(bodyReqeustDTO)],
       requestType: .userProfileSave)
   }
+  
+  static func deleteProfile(
+    with requestDTO: UserIdReqeustDTO
+  ) -> Endpoint<CommonDTO<Bool>> {
+    return Endpoint<CommonDTO<Bool>>(
+      scheme: "http",
+      host: "localhost:8080",
+      method: .delete,
+      parameters: [.query(requestDTO)],
+      requestType: .userProfileDelete)
+  }
 }

--- a/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
+++ b/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
@@ -98,4 +98,21 @@ extension DefaultUserInfoRepository: UserInfoRepository {
         }.store(in: &subscriptions)
     }
   }
+  
+  func deleteProfile() -> Future<Bool, MainError> {
+    // TODO: - UserDefaults 관리 담당 객체를 통해 로그인 한 사용자의 userID를 가져와야 합니다.
+    let requestDTO = UserIdReqeustDTO(userId: 13)
+    let endpoint = UserInfoAPIEndpoint.deleteProfile(with: requestDTO)
+    return Future<Bool, MainError> { [unowned self] promise in
+      service.request(endpoint: endpoint)
+        .mapError { MainError.networkError($0) }
+        .sink { completion in
+          if case .failure(let error) = completion {
+            promise(.failure(error))
+          }
+        } receiveValue: { responseDTO in
+          promise(.success(responseDTO.result))
+        }.store(in: &subscriptions)
+    }
+  }
 }

--- a/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
+++ b/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
@@ -79,4 +79,23 @@ extension DefaultUserInfoRepository: UserInfoRepository {
         }.store(in: &subscriptions)
     }
   }
+  
+  func saveProfile(with profile: String) -> Future<Bool, MainError> {
+    // TODO: - UserDefaults 관리 담당 객체를 통해 로그인 한 사용자의 userID를 가져와야 합니다.
+    let userIdRequestDTO = UserIdReqeustDTO(userId: 13)
+    let requestDTO = UserProfileRequestDTO(profile: profile)
+    let endpoint = UserInfoAPIEndpoint.saveProfile(withQuery: userIdRequestDTO, body: requestDTO)
+    return Future<Bool, MainError> { [unowned self] promise in
+      service.request(endpoint: endpoint)
+        .mapError { MainError.networkError($0) }
+        .sink { completion in
+          if case .failure(let error) = completion {
+            promise(.failure(error))
+          }
+        } receiveValue: { responseDTO in
+          let isSucceed = (200...299).contains(Int(responseDTO.status) ?? -1)
+          promise(.success(isSucceed))
+        }.store(in: &subscriptions)
+    }
+  }
 }

--- a/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
+++ b/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
@@ -115,4 +115,22 @@ extension DefaultUserInfoRepository: UserInfoRepository {
         }.store(in: &subscriptions)
     }
   }
+  
+  func fetchProfile() -> Future<ProfileImageEntity, MainError> {
+    // TODO: - UserDefaults 관리 담당 객체를 통해 로그인 한 사용자의 userID를 가져와야 합니다.
+    let requestDTO = UserIdReqeustDTO(userId: 13)
+    let endpoint = UserInfoAPIEndpoint.fetchProfile(with: requestDTO)
+    return Future<ProfileImageEntity, MainError> { [unowned self] promise in
+      service.request(endpoint: endpoint)
+        .mapError { MainError.networkError($0) }
+        .sink { completion in
+          if case .failure(let error) = completion {
+            promise(.failure(error))
+          }
+        } receiveValue: { responseDTO in
+          let entity = responseDTO.result.toDomain()
+          promise(.success(entity))
+        }.store(in: &subscriptions)
+    }
+  }
 }

--- a/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
+++ b/travelPlan/Source/Data/Repositories/DefaultUserInfoRepository.swift
@@ -63,8 +63,9 @@ extension DefaultUserInfoRepository: UserInfoRepository {
   
   func updateProfile(with profile: String) -> Future<Bool, MainError> {
     // TODO: - UserDefaults 관리 담당 객체를 통해 로그인 한 사용자의 userID를 가져와야 합니다.
-    let requestDTO = UserProfileRequestDTO(profile: profile, userID: 13)
-    let endpoint = UserInfoAPIEndpoint.updateProfile(with: requestDTO)
+    let userIdReqeustDTO = UserIdReqeustDTO(userId: 13)
+    let reqeustDTO = UserProfileRequestDTO(profile: profile)
+    let endpoint = UserInfoAPIEndpoint.updateProfile(withQuery: userIdReqeustDTO, body: reqeustDTO)
     return Future<Bool, MainError> { [unowned self] promise in
       service.request(endpoint: endpoint)
         .mapError { MainError.networkError($0) }

--- a/travelPlan/Source/Domain/Entities/ProfileImageEntity.swift
+++ b/travelPlan/Source/Domain/Entities/ProfileImageEntity.swift
@@ -1,0 +1,12 @@
+//
+//  ProfileImageEntity.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/4/24.
+//
+
+import Foundation
+
+struct ProfileImageEntity {
+  let image: String
+}

--- a/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
@@ -14,4 +14,5 @@ protocol UserInfoRepository {
   func updateProfile(with profile: String) -> Future<Bool, MainError>
   func saveProfile(with profile: String) -> Future<Bool, MainError>
   func deleteProfile() -> Future<Bool, MainError>
+  func fetchProfile() -> Future<ProfileImageEntity, MainError>
 }

--- a/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
@@ -13,5 +13,5 @@ protocol UserInfoRepository {
   func updateUserNickname(with name: String) -> Future<Bool, MainError>
   func updateProfile(with profile: String) -> Future<Bool, MainError>
   func saveProfile(with profile: String) -> Future<Bool, MainError>
-  func deleteProfile(with profile: String) -> Future<Bool, MainError>
+  func deleteProfile() -> Future<Bool, MainError>
 }

--- a/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
@@ -12,4 +12,5 @@ protocol UserInfoRepository {
   func checkIfUserNicknameDuplicate(with name: String) -> Future<Bool, MainError>
   func updateUserNickname(with name: String) -> Future<Bool, MainError>
   func updateProfile(with profile: String) -> Future<Bool, MainError>
+  func saveProfile(with profile: String) -> Future<Bool, MainError>
 }

--- a/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
@@ -13,4 +13,5 @@ protocol UserInfoRepository {
   func updateUserNickname(with name: String) -> Future<Bool, MainError>
   func updateProfile(with profile: String) -> Future<Bool, MainError>
   func saveProfile(with profile: String) -> Future<Bool, MainError>
+  func deleteProfile(with profile: String) -> Future<Bool, MainError>
 }

--- a/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Interfaces/Repositories/UserInfoRepository.swift
@@ -11,4 +11,5 @@ import Combine
 protocol UserInfoRepository {
   func checkIfUserNicknameDuplicate(with name: String) -> Future<Bool, MainError>
   func updateUserNickname(with name: String) -> Future<Bool, MainError>
+  func updateProfile(with profile: String) -> Future<Bool, MainError>
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -34,7 +34,7 @@ final class MockUserInfoRepository: UserInfoRepository {
     return .init { $0(.success(true)) }
   }
   
-  func deleteProfile(with profile: String) -> Future<Bool, MainError> {
+  func deleteProfile() -> Future<Bool, MainError> {
     return .init { $0(.success(true)) }
   }
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -8,9 +8,10 @@
 import Combine
 
 final class MockUserInfoRepository: UserInfoRepository {
-  // 임시
   func updateUserNickname(with name: String) -> Future<Bool, MainError> {
-    return .init { $0(.success(true))}
+    return .init { promise in
+      promise(.success(name == "어려운건 정복해나가는 맛이 있는거지"))
+    }
   }
   
   /// 만약 사용자가 "토익은 어려워"라는 닉네임을 입력했을 때 가정

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -33,4 +33,8 @@ final class MockUserInfoRepository: UserInfoRepository {
   func saveProfile(with profile: String) -> Future<Bool, MainError> {
     return .init { $0(.success(true)) }
   }
+  
+  func deleteProfile(with profile: String) -> Future<Bool, MainError> {
+    return .init { $0(.success(true)) }
+  }
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -37,4 +37,8 @@ final class MockUserInfoRepository: UserInfoRepository {
   func deleteProfile() -> Future<Bool, MainError> {
     return .init { $0(.success(true)) }
   }
+  
+  func fetchProfile() -> Future<ProfileImageEntity, MainError> {
+    return .init { $0(.success(ProfileImageEntity(image: "hi"))) }
+  }
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -32,7 +32,9 @@ final class MockUserInfoRepository: UserInfoRepository {
   }
   
   func saveProfile(with profile: String) -> Future<Bool, MainError> {
-    return .init { $0(.success(true)) }
+    return .init { promise in
+      promise(.success(profile == "성장해나가자보자구!!!"))
+    }
   }
   
   func deleteProfile() -> Future<Bool, MainError> {

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -20,4 +20,9 @@ final class MockUserInfoRepository: UserInfoRepository {
     }
     return .init { $0(.success(false))}
   }
+  
+  // 임시
+  func updateProfile(with profile: String) -> Future<Bool, MainError> {
+    return .init { promise in promise(.success(true))}
+  }
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -29,4 +29,8 @@ final class MockUserInfoRepository: UserInfoRepository {
       promise(.success(false))
     }
   }
+  
+  func saveProfile(with profile: String) -> Future<Bool, MainError> {
+    return .init { $0(.success(true)) }
+  }
 }

--- a/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
+++ b/travelPlan/Source/Domain/Tests/Mock/MockUserInfoRepository.swift
@@ -21,8 +21,12 @@ final class MockUserInfoRepository: UserInfoRepository {
     return .init { $0(.success(false))}
   }
   
-  // 임시
   func updateProfile(with profile: String) -> Future<Bool, MainError> {
-    return .init { promise in promise(.success(true))}
+    return .init { promise in
+      if profile == "base64인코딩된데이터" {
+        promise(.success(true))
+      }
+      promise(.success(false))
+    }
   }
 }

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -83,9 +83,49 @@ final class UserInfoUseCaseTests: XCTestCase {
       "isNicknameUpdated 반환 값이 true여야 하지만 false반환")
   }
   
+  func testuserInfoUseCase_updateProfile함수를통해_프로필업데이트성공적일때_isProfileUpdated프로퍼티가_ShouldReturnEqual() {
+    // Arrange
+    var resultValue = false
+    let expectedValue = true
+    
+    // Act
+    subscription = sut.isProfileUpdated.sink { _ in
+    } receiveValue: { [unowned self] in
+      resultValue = $0
+      expectation.fulfill()
+    }
+    sut.updateProfile(with: "base64인코딩된데이터")
+    wait(for: [expectation], timeout: 3.00001)
+    
+    // Assert
+    XCTAssertEqual(
+      resultValue,
+      expectedValue,
+      "updateProfile()함수를통해 서버에 호출한 결과로 isProfileUdpated프로퍼티가 true가 반환되야하는데 false반환됨.")
+  }
+  
+  func testuserInfoUseCase_updateProfile함수를통해_프로필업데이트가실패했을때_isProfileUpdated프로퍼티가_ShouldReturnFalse() {
+    // Arrange
+    var resultValue = true
+    
+    // Act
+    subscription = sut.isProfileUpdated.sink { _ in
+    } receiveValue: { [unowned self] in
+      resultValue = $0
+      expectation.fulfill()
+    }
+    sut.updateProfile(with: "무슨이유에서인지실패..")
+    wait(for: [expectation], timeout: 3.00001)
+    
+    // Assert
+    XCTAssertFalse(
+      resultValue,
+      "updateProfile()함수를통해 서버에 호출한 결과로 isProfileUdpated프로퍼티가 false가 반환되야하는데 true반환됨.")
+  }
+  
   func testUserInfoUseCase_fetchProfile함수를통해_사용자의프로필을받아올때_fetchedProfile프로퍼티_반환값이예상값과일치하는지_ShouldReturnEqual() {
     // Arrange
-    var expectedProfileEntity = ProfileImageEntity(image: "hi")
+    let expectedProfileEntity = ProfileImageEntity(image: "hi")
     var requestedProfileEntity = ProfileImageEntity(image: "")
     
     // Act

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -45,6 +45,44 @@ final class UserInfoUseCaseTests: XCTestCase {
     wait(for: [expectation], timeout: 5)
   }
   
+  func testUserInfoUseCase_updateNickname함수를통해_이름업데이트할때_이미_다른사용자가_사용중인이름이라면_ShouldReturnFalse() {
+    // Arrange
+    var testResultValue = true
+    
+    // Act
+    subscription = sut.isNicknameUpdated.sink { _ in
+    } receiveValue: { [unowned self] in
+      testResultValue = $0
+      expectation.fulfill()
+    }
+    sut.updateNickname(with: "토익은정말어려워")
+    wait(for: [expectation], timeout: 5)
+    
+    // Assert
+    XCTAssertFalse(
+      testResultValue,
+      "isNicknameUpdated 반환 값이 true여야 하지만 false반환")
+  }
+  
+  func testUserInfoUseCase_updateNickname함수를통해_이름업데이트할때_성공적으로_변경됬다면_ShouldReturnTrue() {
+    // Arrange
+    var testResultValue = false
+    
+    // Act
+    subscription = sut.isNicknameUpdated.sink { _ in
+    } receiveValue: { [unowned self] in
+      testResultValue = $0
+      expectation.fulfill()
+    }
+    sut.updateNickname(with: "어려운건 정복해나가는 맛이 있는거지")
+    wait(for: [expectation], timeout: 3.1)
+    
+    // Assert
+    XCTAssertTrue(
+      testResultValue,
+      "isNicknameUpdated 반환 값이 true여야 하지만 false반환")
+  }
+  
   func testUserInfoUseCase_fetchProfile함수를통해_사용자의프로필을받아올때_fetchedProfile프로퍼티_반환값이예상값과일치하는지_ShouldReturnEqual() {
     // Arrange
     var expectedProfileEntity = ProfileImageEntity(image: "hi")

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -31,7 +31,7 @@ final class UserInfoUseCaseTests: XCTestCase {
   }
   
   // MARK: - Tests
-  func testUserInfoUseCase_사용자의이름이중복됬는지여부를확인할때_ShouldRetrunTrue() {
+  func testUserInfoUseCase_isNicknameDuplicate함수를통해_사용자의이름이중복됬는지여부를확인할때_ShouldRetrunTrue() {
     subscription = sut.isNicknameDuplicated.sink { _ in
     } receiveValue: { [unowned self] requestedValue in
       // Assert

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -83,7 +83,7 @@ final class UserInfoUseCaseTests: XCTestCase {
       "isNicknameUpdated 반환 값이 true여야 하지만 false반환")
   }
   
-  func testuserInfoUseCase_updateProfile함수를통해_프로필업데이트성공적일때_isProfileUpdated프로퍼티가_ShouldReturnEqual() {
+  func testUserInfoUseCase_updateProfile함수를통해_프로필업데이트성공적일때_isProfileUpdated프로퍼티가_ShouldReturnEqual() {
     // Arrange
     var resultValue = false
     let expectedValue = true
@@ -104,7 +104,7 @@ final class UserInfoUseCaseTests: XCTestCase {
       "updateProfile()함수를통해 서버에 호출한 결과로 isProfileUdpated프로퍼티가 true가 반환되야하는데 false반환됨.")
   }
   
-  func testuserInfoUseCase_updateProfile함수를통해_프로필업데이트가실패했을때_isProfileUpdated프로퍼티가_ShouldReturnFalse() {
+  func testUserInfoUseCase_updateProfile함수를통해_프로필업데이트가실패했을때_isProfileUpdated프로퍼티가_ShouldReturnFalse() {
     // Arrange
     var resultValue = true
     
@@ -121,6 +121,44 @@ final class UserInfoUseCaseTests: XCTestCase {
     XCTAssertFalse(
       resultValue,
       "updateProfile()함수를통해 서버에 호출한 결과로 isProfileUdpated프로퍼티가 false가 반환되야하는데 true반환됨.")
+  }
+  
+  func testUserInfoUseCase_saveProfile함수를통해_프로필저장이_성공했을때_isProfileSaved프로퍼티_ShouldReturnTrue() {
+    // Arrange
+    var resultValue = false
+    
+    // Act
+    subscription = sut.isProfileSaved.sink { _ in
+    } receiveValue: { [unowned self] in
+      resultValue = $0
+      expectation.fulfill()
+    }
+    sut.saveProfile(with: "성장해나가자보자구!!!")
+    wait(for: [expectation], timeout: 4)
+    
+    // Assert
+    XCTAssertTrue(
+      resultValue,
+      "saveProfile()함수를통해 서버에 호출한 결과로 isProfileSaved프로퍼티가 true가 반환되야하는데 false반환됨.")
+  }
+  
+  func testUserInfoUseCase_saveProfile함수를통해_프로필저장이_실패했을때_isProfileSaved프로퍼티_ShouldReturnFalse() {
+    // Arrange
+    var resultValue = true
+    
+    // Act
+    subscription = sut.isProfileSaved.sink { _ in
+    } receiveValue: { [unowned self] in
+      resultValue = $0
+      expectation.fulfill()
+    }
+    sut.saveProfile(with: "!!!!")
+    wait(for: [expectation], timeout: 4)
+    
+    // Assert
+    XCTAssertFalse(
+      resultValue,
+      "saveProfile()함수를통해 서버에 호출한 결과로 isProfileSaved프로퍼티가 false가 반환되야하는데 true반환됨.")
   }
   
   func testUserInfoUseCase_fetchProfile함수를통해_사용자의프로필을받아올때_fetchedProfile프로퍼티_반환값이예상값과일치하는지_ShouldReturnEqual() {

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -161,6 +161,25 @@ final class UserInfoUseCaseTests: XCTestCase {
       "saveProfile()함수를통해 서버에 호출한 결과로 isProfileSaved프로퍼티가 false가 반환되야하는데 true반환됨.")
   }
   
+  func testUserInfoUseCase_deleteProfile함수를통해_프로필삭제했을때_isProfileDeleted프로퍼티_ShouldReturnTrue() {
+    // Arrange
+    var resultValue = false
+    
+    // Act
+    subscription = sut.isProfileDeleted.sink { _ in
+    } receiveValue: { [unowned self] in
+      resultValue = $0
+      expectation.fulfill()
+    }
+    sut.deleteProfile()
+    wait(for: [expectation], timeout: 4)
+    
+    // Assert
+    XCTAssertTrue(
+      resultValue,
+      "deleteProfile()함수를통해 서버에 호출한 결과로 isProfileDeleted프로퍼티가 false가 반환되야하는데 true반환됨.")
+  }
+  
   func testUserInfoUseCase_fetchProfile함수를통해_사용자의프로필을받아올때_fetchedProfile프로퍼티_반환값이예상값과일치하는지_ShouldReturnEqual() {
     // Arrange
     let expectedProfileEntity = ProfileImageEntity(image: "hi")

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -44,4 +44,25 @@ final class UserInfoUseCaseTests: XCTestCase {
     
     wait(for: [expectation], timeout: 5)
   }
+  
+  func testUserInfoUseCase_fetchProfile함수를통해_사용자의프로필을받아올때_fetchedProfile프로퍼티_반환값이예상값과일치하는지_ShouldReturnEqual() {
+    // Arrange
+    var expectedProfileEntity = ProfileImageEntity(image: "hi")
+    var requestedProfileEntity = ProfileImageEntity(image: "")
+    
+    // Act
+    subscription = sut.fetchedProfile.sink { _ in
+    } receiveValue: { [unowned self] requestedValue in
+      requestedProfileEntity = requestedValue
+      expectation.fulfill()
+    }
+    sut.fetchProfile()
+    wait(for: [expectation], timeout: 5)
+    
+    // Assert
+    XCTAssertEqual(
+      expectedProfileEntity.image,
+      requestedProfileEntity.image,
+      "isDuplicatedName 변수 반환값이 true여야 하지만 false 반환")
+  }
 }

--- a/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
+++ b/travelPlan/Source/Domain/Tests/UserInfoUseCaseTests.swift
@@ -31,7 +31,7 @@ final class UserInfoUseCaseTests: XCTestCase {
   }
   
   // MARK: - Tests
-  func testUserInfoUseCase_isNicknameDuplicate함수를통해_사용자의이름이중복됬는지여부를확인할때_ShouldRetrunTrue() {
+  func testUserInfoUseCase_checkIfNicknameDuplicate함수를통해_사용자의이름이중복됬는지여부를확인할때_ShouldRetrunTrue() {
     subscription = sut.isNicknameDuplicated.sink { _ in
     } receiveValue: { [unowned self] requestedValue in
       // Assert

--- a/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
@@ -5,6 +5,7 @@
 //  Created by 양승현 on 2/27/24.
 //
 
+import Foundation
 import Combine
 
 final class DefaultUserInfoUseCase: UserInfoUseCase {
@@ -15,6 +16,8 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
   var isNicknameDuplicated = PassthroughSubject<Bool, MainError>()
   
   var isNicknameUpdated = PassthroughSubject<Bool, MainError>()
+  
+  var isProfileUpdated = PassthroughSubject<Bool, MainError>()
   
   private var subscriptions = Set<AnyCancellable>()
   
@@ -48,6 +51,18 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
         }
       } receiveValue: { [weak self] result in
         self?.isNicknameUpdated.send(result)
+      }.store(in: &subscriptions)
+  }
+  
+  func updateProfile(with base64String: String) {
+    userInfoRepository.updateProfile(with: base64String)
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] completion in
+        if case .failure(let error) = completion {
+          self?.isProfileUpdated.send(completion: .failure(error))
+        }
+      } receiveValue: { [weak self] result in
+        self?.isProfileUpdated.send(result)
       }.store(in: &subscriptions)
   }
 }

--- a/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
@@ -21,6 +21,8 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
   
   var isProfileSaved = PassthroughSubject<Bool, MainError>()
   
+  var isProfileDeleted = PassthroughSubject<Bool, MainError>()
+  
   private var subscriptions = Set<AnyCancellable>()
   
   // MARK: - Lifecycle
@@ -74,6 +76,18 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
       .sink { [weak self] completion in
         if case .failure(let error) = completion {
           self?.isProfileSaved.send(completion: .failure(error))
+        }
+      } receiveValue: { [weak self] result in
+        self?.isProfileSaved.send(result)
+      }.store(in: &subscriptions)
+  }
+  
+  func deleteProfile() {
+    userInfoRepository.deleteProfile()
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] completion in
+        if case .failure(let error) = completion {
+          self?.isProfileDeleted.send(completion: .failure(error))
         }
       } receiveValue: { [weak self] result in
         self?.isProfileSaved.send(result)

--- a/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
@@ -92,7 +92,7 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
           self?.isProfileDeleted.send(completion: .failure(error))
         }
       } receiveValue: { [weak self] result in
-        self?.isProfileSaved.send(result)
+        self?.isProfileDeleted.send(result)
       }.store(in: &subscriptions)
   }
   

--- a/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/DefaultUserInfoUseCase.swift
@@ -19,7 +19,7 @@ final class DefaultUserInfoUseCase: UserInfoUseCase {
   
   var isProfileUpdated = PassthroughSubject<Bool, MainError>()
   
-  var isProfileSaved: PassthroughSubject<Bool, MainError>
+  var isProfileSaved = PassthroughSubject<Bool, MainError>()
   
   private var subscriptions = Set<AnyCancellable>()
   

--- a/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
@@ -10,7 +10,9 @@ import Combine
 protocol UserInfoUseCase {
   var isNicknameDuplicated: PassthroughSubject<Bool, MainError> { get }
   var isNicknameUpdated: PassthroughSubject<Bool, MainError> { get }
+  var isProfileUpdated: PassthroughSubject<Bool, MainError> { get }
   
   func checkIfNicknameDuplicate(with name: String)
   func updateNickname(with name: String)
+  func updateProfile(with base64String: String)
 }

--- a/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
@@ -12,9 +12,11 @@ protocol UserInfoUseCase {
   var isNicknameUpdated: PassthroughSubject<Bool, MainError> { get }
   var isProfileUpdated: PassthroughSubject<Bool, MainError> { get }
   var isProfileSaved: PassthroughSubject<Bool, MainError> { get }
+  var isProfileDeleted: PassthroughSubject<Bool, MainError> { get }
   
   func checkIfNicknameDuplicate(with name: String)
   func updateNickname(with name: String)
   func updateProfile(with base64String: String)
   func saveProfile(with base64String: String)
+  func deleteProfile()
 }

--- a/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
@@ -11,8 +11,10 @@ protocol UserInfoUseCase {
   var isNicknameDuplicated: PassthroughSubject<Bool, MainError> { get }
   var isNicknameUpdated: PassthroughSubject<Bool, MainError> { get }
   var isProfileUpdated: PassthroughSubject<Bool, MainError> { get }
+  var isProfileSaved: PassthroughSubject<Bool, MainError> { get }
   
   func checkIfNicknameDuplicate(with name: String)
   func updateNickname(with name: String)
   func updateProfile(with base64String: String)
+  func saveProfile(with base64String: String)
 }

--- a/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
+++ b/travelPlan/Source/Domain/UseCases/Protocol/UserInfoUseCase.swift
@@ -13,10 +13,12 @@ protocol UserInfoUseCase {
   var isProfileUpdated: PassthroughSubject<Bool, MainError> { get }
   var isProfileSaved: PassthroughSubject<Bool, MainError> { get }
   var isProfileDeleted: PassthroughSubject<Bool, MainError> { get }
+  var fetchedProfile: PassthroughSubject<ProfileImageEntity, MainError> { get }
   
   func checkIfNicknameDuplicate(with name: String)
   func updateNickname(with name: String)
   func updateProfile(with base64String: String)
   func saveProfile(with base64String: String)
   func deleteProfile()
+  func fetchProfile()
 }

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -140,6 +140,8 @@
 		152AD5272A1B89D2008A2A11 /* FavoriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */; };
 		152AD52A2A1B8D6E008A2A11 /* MockFavoriteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */; };
 		153841D72A5642A9004C41D1 /* PostViewBottomSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */; };
+		153FA90D2B937D9E006CF3C3 /* UserProfileRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */; };
+		153FA90F2B937E12006CF3C3 /* UserProfileResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153FA90E2B937E12006CF3C3 /* UserProfileResponseDTO.swift */; };
 		1546DF242B0A70C900B49A55 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF232B0A70C900B49A55 /* Cache.swift */; };
 		1546DF282B0A7CE400B49A55 /* Cache+Nested.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF272B0A7CE400B49A55 /* Cache+Nested.swift */; };
 		1546DF302B0AF4C100B49A55 /* ImageMemoryCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1546DF2F2B0AF4C100B49A55 /* ImageMemoryCache.swift */; };
@@ -532,6 +534,8 @@
 		152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewModel.swift; sourceTree = "<group>"; };
 		152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFavoriteUseCase.swift; sourceTree = "<group>"; };
 		153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewBottomSheetCell.swift; sourceTree = "<group>"; };
+		153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileRequestDTO.swift; sourceTree = "<group>"; };
+		153FA90E2B937E12006CF3C3 /* UserProfileResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileResponseDTO.swift; sourceTree = "<group>"; };
 		1546DF232B0A70C900B49A55 /* Cache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Cache.swift; sourceTree = "<group>"; };
 		1546DF272B0A7CE400B49A55 /* Cache+Nested.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cache+Nested.swift"; sourceTree = "<group>"; };
 		1546DF2F2B0AF4C100B49A55 /* ImageMemoryCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageMemoryCache.swift; sourceTree = "<group>"; };
@@ -1216,6 +1220,7 @@
 			children = (
 				151DF1042AEEBE0F00D5D55B /* NoticeResponseDTO.swift */,
 				15D655832B8E085300466FEC /* CommonDTO.swift */,
+				153FA90E2B937E12006CF3C3 /* UserProfileResponseDTO.swift */,
 			);
 			path = ResponseDTO;
 			sourceTree = "<group>";
@@ -1794,6 +1799,7 @@
 			children = (
 				15D655862B8E0ABF00466FEC /* UserNicknameRequestDTO.swift */,
 				155D0BAB2B90CB5B0042DFB6 /* UserNicknamePatchRequestDTO.swift */,
+				153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */,
 			);
 			path = RequestDTO;
 			sourceTree = "<group>";
@@ -2460,6 +2466,7 @@
 				13BF41202ADBEC8C00F3F082 /* LoginStartView.swift in Sources */,
 				151DF0F62AEEB2D200D5D55B /* DefaultNoticeUseCase.swift in Sources */,
 				15FFABFB2AD5B6FC0013DB57 /* BasePaddingLabel.swift in Sources */,
+				153FA90F2B937E12006CF3C3 /* UserProfileResponseDTO.swift in Sources */,
 				151DF1012AEEBD0A00D5D55B /* NotificationAPIEndpoints.swift in Sources */,
 				15259DE92ACAA98F00C14F62 /* TravelDestinationCellViewModel.swift in Sources */,
 				15EB39E62AC303C90025FFB4 /* BaseProfileAreaView.swift in Sources */,
@@ -2468,6 +2475,7 @@
 				13813A212AAA458000AF6AEB /* PostSearchCollectionViewDataSource.swift in Sources */,
 				15F0D1B42A51BFB800D04773 /* PostSearchCoordiantor.swift in Sources */,
 				15F0D19A2A4EF49700D04773 /* CategoryPageViewAdapter.swift in Sources */,
+				153FA90D2B937D9E006CF3C3 /* UserProfileRequestDTO.swift in Sources */,
 				15D867CD2AD4003E00F35811 /* FavoriteViewModelable.swift in Sources */,
 				152AD52A2A1B8D6E008A2A11 /* MockFavoriteUseCase.swift in Sources */,
 				139DEE102B16ADF300363E7B /* SearchDestinationServiceCell.swift in Sources */,

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -245,6 +245,7 @@
 		15C1F55F2AF3CDD4005FDA15 /* SettingTopSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C1F55E2AF3CDD4005FDA15 /* SettingTopSheetView.swift */; };
 		15C1F5612AF3D17D005FDA15 /* CALayer+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C1F5602AF3D17D005FDA15 /* CALayer+.swift */; };
 		15C1F5632AF408D3005FDA15 /* SettingType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C1F5622AF408D3005FDA15 /* SettingType.swift */; };
+		15C7A51A2B94DA2800C79E27 /* UserIdReqeustDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C7A5192B94DA2800C79E27 /* UserIdReqeustDTO.swift */; };
 		15C83F882AB2055E00DDB536 /* BaseBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */; };
 		15C83F8A2AB2134D00DDB536 /* BottomSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15C83F892AB2134D00DDB536 /* BottomSheetView.swift */; };
 		15CB235B2A109CA4003EAF20 /* PostHeaderContentBottomInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CB235A2A109CA4003EAF20 /* PostHeaderContentBottomInfo.swift */; };
@@ -641,6 +642,7 @@
 		15C1F55E2AF3CDD4005FDA15 /* SettingTopSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTopSheetView.swift; sourceTree = "<group>"; };
 		15C1F5602AF3D17D005FDA15 /* CALayer+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CALayer+.swift"; sourceTree = "<group>"; };
 		15C1F5622AF408D3005FDA15 /* SettingType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingType.swift; sourceTree = "<group>"; };
+		15C7A5192B94DA2800C79E27 /* UserIdReqeustDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserIdReqeustDTO.swift; sourceTree = "<group>"; };
 		15C83F872AB2055E00DDB536 /* BaseBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseBottomSheetViewController.swift; sourceTree = "<group>"; };
 		15C83F892AB2134D00DDB536 /* BottomSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetView.swift; sourceTree = "<group>"; };
 		15CB235A2A109CA4003EAF20 /* PostHeaderContentBottomInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHeaderContentBottomInfo.swift; sourceTree = "<group>"; };
@@ -1802,6 +1804,7 @@
 				15D655862B8E0ABF00466FEC /* UserNicknameRequestDTO.swift */,
 				155D0BAB2B90CB5B0042DFB6 /* UserNicknamePatchRequestDTO.swift */,
 				153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */,
+				15C7A5192B94DA2800C79E27 /* UserIdReqeustDTO.swift */,
 			);
 			path = RequestDTO;
 			sourceTree = "<group>";
@@ -2607,6 +2610,7 @@
 				15F2A0182B14E32B0014603D /* MyInformationViewController.swift in Sources */,
 				155D0BAC2B90CB5B0042DFB6 /* UserNicknamePatchRequestDTO.swift in Sources */,
 				13254FF02A0549D200094218 /* TabBarCase.swift in Sources */,
+				15C7A51A2B94DA2800C79E27 /* UserIdReqeustDTO.swift in Sources */,
 				13254FEB2A0515C700094218 /* FavoriteViewController.swift in Sources */,
 				151DF0E72AEEA76500D5D55B /* NoticeViewModel.swift in Sources */,
 				13A93EFB2AD1EA6B00FC4BBD /* TravelDestinationModel.swift in Sources */,

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -139,6 +139,7 @@
 		152AD5202A1A09E8008A2A11 /* FavoriteTableViewAdapterDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD51F2A1A09E8008A2A11 /* FavoriteTableViewAdapterDelegate.swift */; };
 		152AD5272A1B89D2008A2A11 /* FavoriteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */; };
 		152AD52A2A1B8D6E008A2A11 /* MockFavoriteUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */; };
+		15329CEC2B96171B005FC033 /* ProfileImageEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15329CEB2B96171B005FC033 /* ProfileImageEntity.swift */; };
 		153841D72A5642A9004C41D1 /* PostViewBottomSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */; };
 		153FA90D2B937D9E006CF3C3 /* UserProfileRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */; };
 		153FA90F2B937E12006CF3C3 /* UserProfileResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 153FA90E2B937E12006CF3C3 /* UserProfileResponseDTO.swift */; };
@@ -535,6 +536,7 @@
 		152AD51F2A1A09E8008A2A11 /* FavoriteTableViewAdapterDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewAdapterDelegate.swift; sourceTree = "<group>"; };
 		152AD5262A1B89D2008A2A11 /* FavoriteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteViewModel.swift; sourceTree = "<group>"; };
 		152AD5292A1B8D6E008A2A11 /* MockFavoriteUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockFavoriteUseCase.swift; sourceTree = "<group>"; };
+		15329CEB2B96171B005FC033 /* ProfileImageEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProfileImageEntity.swift; sourceTree = "<group>"; };
 		153841D62A5642A9004C41D1 /* PostViewBottomSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewBottomSheetCell.swift; sourceTree = "<group>"; };
 		153FA90C2B937D9E006CF3C3 /* UserProfileRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileRequestDTO.swift; sourceTree = "<group>"; };
 		153FA90E2B937E12006CF3C3 /* UserProfileResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserProfileResponseDTO.swift; sourceTree = "<group>"; };
@@ -1149,6 +1151,7 @@
 				15F376632AFE134400B3BF35 /* PostReplyEntity.swift */,
 				15C1F5622AF408D3005FDA15 /* SettingType.swift */,
 				15FBA7E42B1343CB00C9B1E7 /* PostThumbnailValue.swift */,
+				15329CEB2B96171B005FC033 /* ProfileImageEntity.swift */,
 			);
 			path = Entities;
 			sourceTree = "<group>";
@@ -2645,6 +2648,7 @@
 				13A93EF72AD0AD2700FC4BBD /* SearchTopTenCell.swift in Sources */,
 				15D388232AFE75E100039946 /* PostDetailReplyCell.swift in Sources */,
 				13254FFB2A08AD8700094218 /* PostSearchViewController.swift in Sources */,
+				15329CEC2B96171B005FC033 /* ProfileImageEntity.swift in Sources */,
 				15C83F882AB2055E00DDB536 /* BaseBottomSheetViewController.swift in Sources */,
 				15FFAC152ADA83E00013DB57 /* SessionProvider.swift in Sources */,
 				15710CBC2A132DD00023C19E /* FeedAppTitleBarItem.swift in Sources */,


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

- API METHODS - USERPROFILEIMAGECONTROLLER 
  - delete, fetch, save, update 컨트롤러 관련 Domain, Data layer 구현.

- UserInfoAPIEndpoint delete, fetch, save, update profile관련 unit test.
- UserInfoUseCase unit test.
- swiftLint에 Tests 관련 파일 전부 예외 처리하도록 했습니다.

---

![스크린샷 2024-03-05 오전 1 25 04](https://github.com/IF-TG/iOS/assets/96910404/1b8a8000-8ce4-42e5-bd6d-b98621dfadb7)

UserInfoUseCase 테스트할 때 MockUserInfoRepository에서 예정된 값만 반환해서 너무 예정된 값만 반환하는거 같아 테스트 안 하려다,, 그래도 해봤는데 작성했던 잘못된 코드를 발견하게됬습니다 😅😁😅😁

