### PR TITLE
[Feature] 피드화면 포스트 정렬 presentation layer - Domain layer 연동 구현했습니다.

### DIFF
--- a/travelPlan/Source/Common/Extension/Notification+.swift
+++ b/travelPlan/Source/Common/Extension/Notification+.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Notification.Name {
-  /// FeedPage에서 분류 및 최신순 눌렀을 때
+  /// FeedPage에서 분류 및 정렬 눌렀을 때
   static let TravelCategoryDetailSelected = Notification
     .Name("travelCategoryDetailSelected")
 }

--- a/travelPlan/Source/Data/Network/DataMapper/TravelMainThemeTypeMapper.swift
+++ b/travelPlan/Source/Data/Network/DataMapper/TravelMainThemeTypeMapper.swift
@@ -26,19 +26,23 @@ struct TravelMainThemeTypeMapper {
   }
   
   static func toSubCategoryDTO(_ requestValue: TravelMainThemeType) -> String? {
-    return switch requestValue {
+    switch requestValue {
     case .all:
-      nil
+      return nil
     case .season(let season):
-      SeasonMapper.toDTO(season)
+      guard let season else { return nil }
+      return SeasonMapper.toDTO(season)
     case .region(let travelRegion):
-      TravelRegionMapper.toDTO(travelRegion)
+      guard let travelRegion else { return nil }
+      return TravelRegionMapper.toDTO(travelRegion)
     case .travelTheme(let travelTheme):
-      TravelThemeMapper.toDTO(travelTheme)
+      guard let travelTheme else { return nil }
+      return TravelThemeMapper.toDTO(travelTheme)
     case .partner(let travelPartner):
-      TravelPartnerMapper.toDTO(travelPartner)
+      guard let travelPartner else { return nil }
+      return TravelPartnerMapper.toDTO(travelPartner)
     case .categoryDevelop:
-      nil
+      return nil
     }
   }
 }

--- a/travelPlan/Source/Domain/Entities/TravelCategory/TravelMainThemeType.swift
+++ b/travelPlan/Source/Domain/Entities/TravelCategory/TravelMainThemeType.swift
@@ -9,18 +9,18 @@ import Foundation
 
 @frozen enum TravelMainThemeType: CaseIterable {
   case all
-  case season(Season)
-  case region(TravelRegion)
-  case travelTheme(TravelTheme)
-  case partner(TravelPartner)
+  case season(Season?)
+  case region(TravelRegion?)
+  case travelTheme(TravelTheme?)
+  case partner(TravelPartner?)
   case categoryDevelop
   
   static var allCases: [TravelMainThemeType] {
     [.all,
-     .season(Season.spring),
-     .region(TravelRegion.busan),
-     .travelTheme(TravelTheme.local),
-     .partner(TravelPartner.alone),
+     .season(nil),
+     .region(nil),
+     .travelTheme(nil),
+     .partner(nil),
      .categoryDevelop]
   }
   
@@ -66,13 +66,13 @@ extension TravelMainThemeType: RawRepresentable {
     case "전체":
       self = .all
     case "계절":
-      self = .season(Season.spring)
+      self = .season(nil)
     case "지역":
-      self = .region(TravelRegion.busan)
+      self = .region(nil)
     case "여행 테마":
-      self = .travelTheme(TravelTheme.adventure)
+      self = .travelTheme(nil)
     case "동반자":
-      self = .partner(TravelPartner.alone)
+      self = .partner(nil)
     case "???":
       self = .categoryDevelop
     default:

--- a/travelPlan/Source/Domain/Entities/TravelCategory/TravelOrderType.swift
+++ b/travelPlan/Source/Domain/Entities/TravelCategory/TravelOrderType.swift
@@ -7,18 +7,7 @@
 
 import Foundation
 
-@frozen enum TravelOrderType: String, CaseIterable, Equatable, RawRepresentable {
+@frozen enum TravelOrderType: String, CaseIterable, Equatable {
   case newest = "최신순"
   case popularity = "인기순"
-  
-  init?(rawValue: String) {
-    switch rawValue {
-    case TravelOrderType.newest.rawValue:
-      self = .newest
-    case TravelOrderType.popularity.rawValue:
-      self = .popularity
-    default:
-      return nil
-    }
-  }
 }

--- a/travelPlan/Source/Domain/Entities/TravelCategory/TravelOrderType.swift
+++ b/travelPlan/Source/Domain/Entities/TravelCategory/TravelOrderType.swift
@@ -7,7 +7,18 @@
 
 import Foundation
 
-@frozen enum TravelOrderType: String, CaseIterable, Equatable {
+@frozen enum TravelOrderType: String, CaseIterable, Equatable, RawRepresentable {
   case newest = "최신순"
   case popularity = "인기순"
+  
+  init?(rawValue: String) {
+    switch rawValue {
+    case TravelOrderType.newest.rawValue:
+      self = .newest
+    case TravelOrderType.popularity.rawValue:
+      self = .popularity
+    default:
+      return nil
+    }
+  }
 }

--- a/travelPlan/Source/Presentation/Feed/Coordinator/FeedCoordinator.swift
+++ b/travelPlan/Source/Presentation/Feed/Coordinator/FeedCoordinator.swift
@@ -12,8 +12,8 @@ protocol FeedCoordinatorDelegate: FlowCoordinatorDelegate {
   func showPostSearch()
   func showNotification()
   func showTotalBottomSheet()
-  func showPostMainThemeFilteringBottomSheet(sortingType: TravelMainThemeType)
-  func showPostOrderFilteringBottomSheet()
+  func showPostMainThemeCategoryBottomSheet(mainTheme: TravelMainThemeType)
+  func showPostOrderCategoryBottomSheet()
   func showReviewWrite()
 }
 
@@ -82,27 +82,18 @@ extension FeedCoordinator: FeedCoordinatorDelegate {
     presenter?.present(sheetViewController, animated: false)
   }
   
-  func showPostMainThemeFilteringBottomSheet(sortingType: TravelMainThemeType) {
-    var bottomSheetViewController: PostFilteringBottomSheetViewController
-    if sortingType.rawValue == "지역" {
-      bottomSheetViewController = PostFilteringBottomSheetViewController(
-        bottomSheetMode: .full,
-        sortingType: .travelMainTheme(.region(.busan)))
-    } else {
-      bottomSheetViewController = PostFilteringBottomSheetViewController(
-        bottomSheetMode: .couldBeFull,
-        sortingType: .travelMainTheme(sortingType))
-    }
-    bottomSheetViewController.delegate = viewController
-    presenter?.presentBottomSheet(bottomSheetViewController)
+  // FIXME: - 피드 탭에서 분류, 최신순 title은 그대로 두고 이제 바텀시트 올라올 때 선택됬던거는 얕은 회식으로 표시?
+  // 카테고리 선정시 옆에 태그 형식으로 붙여주는것도 괜찮은 선택지,,
+  func showPostMainThemeCategoryBottomSheet(mainTheme: TravelMainThemeType) {
+    let bottomSheet = PostMainThemeCategoryBottomSheet(mainTheme: mainTheme)
+    bottomSheet.delegate = viewController
+    presenter?.presentBottomSheet(bottomSheet)
   }
   
-  func showPostOrderFilteringBottomSheet() {
-    let bottomSheetViewController = PostFilteringBottomSheetViewController(
-      bottomSheetMode: .couldBeFull,
-      sortingType: .travelOrder)
-    bottomSheetViewController.delegate = viewController
-    presenter?.presentBottomSheet(bottomSheetViewController)
+  func showPostOrderCategoryBottomSheet() {
+    let bottomSheet = PostOrderCategoryBottomSheet()
+    bottomSheet.delegate = viewController
+    presenter?.presentBottomSheet(bottomSheet)
   }
   
   func showReviewWrite() {

--- a/travelPlan/Source/Presentation/Feed/Coordinator/FeedCoordinator.swift
+++ b/travelPlan/Source/Presentation/Feed/Coordinator/FeedCoordinator.swift
@@ -82,7 +82,7 @@ extension FeedCoordinator: FeedCoordinatorDelegate {
     presenter?.present(sheetViewController, animated: false)
   }
   
-  // FIXME: - 피드 탭에서 분류, 최신순 title은 그대로 두고 이제 바텀시트 올라올 때 선택됬던거는 얕은 회식으로 표시?
+  // FIXME: - 피드 탭에서 분류, 정렬 title은 그대로 두고 이제 바텀시트 올라올 때 선택됬던거는 얕은 회식으로 표시?
   // 카테고리 선정시 옆에 태그 형식으로 붙여주는것도 괜찮은 선택지,,
   func showPostMainThemeCategoryBottomSheet(mainTheme: TravelMainThemeType) {
     let bottomSheet = PostMainThemeCategoryBottomSheet(mainTheme: mainTheme)

--- a/travelPlan/Source/Presentation/Feed/Model/PostFilterOptions.swift
+++ b/travelPlan/Source/Presentation/Feed/Model/PostFilterOptions.swift
@@ -7,52 +7,16 @@
 
 import Foundation
 
-enum PostFilterOptions {
-  // TODO: - 이것도 TravelOrderType associated value줘야 할거같은데,
+@frozen enum PostFilterOptions {
   case travelOrder
   case travelMainTheme(TravelMainThemeType)
-  
-  var toIndex: Int {
-    switch self {
-    case .travelOrder:
-      return 0
-    case .travelMainTheme:
-      return 1
-    }
-  }
-  
-  var subCateogryTitles: [String] {
-    switch self {
-    case .travelOrder:
-      /// 인기순 최신순
-      return TravelOrderType.allCases.map { $0.rawValue }
-    case .travelMainTheme(let travelThemeType):
-      /// 지역일 경우 서울,  경기 ... 17개
-      return travelThemeType.titles
-    }
-  }
-}
-
-// MARK: - RawRepresentable
-extension PostFilterOptions: RawRepresentable {
-  init?(rawValue: String) {
-    switch rawValue {
-    case "최신순":
-      self = .travelOrder
-    case "분류":
-      self = .travelMainTheme(.all)
-    default:
-      return nil
-    }
-  }
   
   var rawValue: String {
     switch self {
     case .travelOrder:
-      return "최신순"
+      return "정렬"
     case .travelMainTheme:
       return "분류"
     }
   }
-  
 }

--- a/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
+++ b/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
@@ -54,14 +54,14 @@ final class CategoryPageView: UIView {
 
 // MARK: - Helpers
 extension CategoryPageView {
-  func setOrderCategoryHeaderDefaultUI(type: TravelOrderType) {
+  func setOrderCategoryHeaderDefaultUI() {
     guard let targetViewController = postPageViewController.viewControllers?
       .first as? FeedPostViewController 
     else { return }
     targetViewController.setDefaultOrderUI()
   }
   
-  func setMainThemeCategoryHeaderDefaultUI(type: TravelMainThemeType) {
+  func setMainThemeCategoryHeaderDefaultUI() {
     guard let targetViewController = postPageViewController.viewControllers?
       .first as? FeedPostViewController
     else { return }

--- a/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
+++ b/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
@@ -54,16 +54,18 @@ final class CategoryPageView: UIView {
 
 // MARK: - Helpers
 extension CategoryPageView {
-  func setDefaultSortingHeaderUI(from sortingType: PostFilterOptions) {
+  func setOrderCategoryHeaderDefaultUI(type: TravelOrderType) {
+    guard let targetViewController = postPageViewController.viewControllers?
+      .first as? FeedPostViewController 
+    else { return }
+    targetViewController.setDefaultOrderUI()
+  }
+  
+  func setMainThemeCategoryHeaderDefaultUI(type: TravelMainThemeType) {
     guard let targetViewController = postPageViewController.viewControllers?
       .first as? FeedPostViewController
     else { return }
-    switch sortingType {
-    case .travelOrder:
-      targetViewController.setDefaultOrderUI()
-    case .travelMainTheme:
-      targetViewController.setDefaultThemeUI()
-    }
+    targetViewController.setDefaultThemeUI()
   }
 }
 

--- a/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
+++ b/travelPlan/Source/Presentation/Feed/View/CategoryPageView/CategoryPageView.swift
@@ -54,18 +54,18 @@ final class CategoryPageView: UIView {
 
 // MARK: - Helpers
 extension CategoryPageView {
-  func setOrderCategoryHeaderDefaultUI() {
-    guard let targetViewController = postPageViewController.viewControllers?
-      .first as? FeedPostViewController 
-    else { return }
-    targetViewController.setDefaultOrderUI()
-  }
-  
-  func setMainThemeCategoryHeaderDefaultUI() {
+  func handleOrderTypeFilter(with orderType: TravelOrderType?) {
     guard let targetViewController = postPageViewController.viewControllers?
       .first as? FeedPostViewController
     else { return }
-    targetViewController.setDefaultThemeUI()
+    targetViewController.handleOrderTypeFilter(with: orderType)
+  }
+  
+  func handleMainThemeFilter(with mainTheme: TravelMainThemeType?) {
+    guard let targetViewController = postPageViewController.viewControllers?
+      .first as? FeedPostViewController
+    else { return }
+    targetViewController.handleMainThemeFilter(with: mainTheme)
   }
 }
 

--- a/travelPlan/Source/Presentation/Feed/View/PostView/PostSortingAreaView.swift
+++ b/travelPlan/Source/Presentation/Feed/View/PostView/PostSortingAreaView.swift
@@ -11,13 +11,13 @@ final class PostSortingAreaView: UICollectionReusableView {
   static let id = String(describing: PostSortingAreaView.self)
   
   enum Constant {
-    enum TravelThemeChevronView {
+    enum TravelMainThemeChevronView {
       enum Spacing {
         static let leading: CGFloat = 16
         static let top: CGFloat = 10
       }
     }
-    enum TravelTrendChevronView {
+    enum TravelOrderChevronView {
       enum Spacing {
         static let leading: CGFloat = 10
         static let top: CGFloat = 10
@@ -27,18 +27,18 @@ final class PostSortingAreaView: UICollectionReusableView {
   
   // MARK: - Properties
   /// 분류
-  private var travelThemeChevronView = PostChevronLabel()
+  private var travelMainThemeChevronView = PostChevronLabel()
   
   /// 정렬
-  private var travelTrendChevronView = PostChevronLabel()
+  private var travelOrderChevronView = PostChevronLabel()
   
   // MARK: - LifeCycle
   override init(frame: CGRect) {
     super.init(frame: frame)
-    travelTrendChevronView.configure(with: .travelOrder)
+    travelOrderChevronView.configure(with: .travelOrder)
     setupUI()
-    travelThemeChevronView.delegate = self
-    travelTrendChevronView.delegate = self
+    travelMainThemeChevronView.delegate = self
+    travelOrderChevronView.delegate = self
   }
   
   required init?(coder: NSCoder) { fatalError() }
@@ -51,15 +51,15 @@ final class PostSortingAreaView: UICollectionReusableView {
 // MARK: - Helpers
 extension PostSortingAreaView {
   func configure(with sortingType: PostFilterOptions) {
-    travelThemeChevronView.configure(with: sortingType)
+    travelMainThemeChevronView.configure(with: sortingType)
   }
   
   func setDefaultThemeUI() {
-    travelThemeChevronView.isSelected = false
+    travelMainThemeChevronView.isSelected = false
   }
   
   func setDefaultOrderUI() {
-    travelTrendChevronView.isSelected = false
+    travelOrderChevronView.isSelected = false
   }
 }
 
@@ -67,8 +67,8 @@ extension PostSortingAreaView {
 extension PostSortingAreaView: LayoutSupport {
   func addSubviews() {
     _=[
-      travelThemeChevronView,
-      travelTrendChevronView
+      travelMainThemeChevronView,
+      travelOrderChevronView
     ].map {
       addSubview($0)
     }
@@ -101,19 +101,19 @@ extension PostSortingAreaView: MoreMenuViewDelegate {
 // MARK: - Private layoutsupport
 private extension PostSortingAreaView {
   var travelThemeMenuViewConstraints: [NSLayoutConstraint] {
-    typealias Inset = Constant.TravelThemeChevronView.Spacing
+    typealias Inset = Constant.TravelMainThemeChevronView.Spacing
     return [
-      travelThemeChevronView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Inset.leading),
-      travelThemeChevronView.topAnchor.constraint(equalTo: topAnchor, constant: Inset.top),
-      travelThemeChevronView.bottomAnchor.constraint(equalTo: bottomAnchor)]
+      travelMainThemeChevronView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Inset.leading),
+      travelMainThemeChevronView.topAnchor.constraint(equalTo: topAnchor, constant: Inset.top),
+      travelMainThemeChevronView.bottomAnchor.constraint(equalTo: bottomAnchor)]
   }
   
   var travelTrendMenuViewConstraints: [NSLayoutConstraint] {
-    typealias Inset = Constant.TravelTrendChevronView.Spacing
+    typealias Inset = Constant.TravelOrderChevronView.Spacing
     return [
-      travelTrendChevronView.leadingAnchor.constraint(
-        equalTo: travelThemeChevronView.trailingAnchor,
+      travelOrderChevronView.leadingAnchor.constraint(
+        equalTo: travelMainThemeChevronView.trailingAnchor,
         constant: Inset.leading),
-      travelTrendChevronView.centerYAnchor.constraint(equalTo: travelThemeChevronView.centerYAnchor)]
+      travelOrderChevronView.centerYAnchor.constraint(equalTo: travelMainThemeChevronView.centerYAnchor)]
   }
 }

--- a/travelPlan/Source/Presentation/Feed/View/PostView/PostSortingAreaView.swift
+++ b/travelPlan/Source/Presentation/Feed/View/PostView/PostSortingAreaView.swift
@@ -29,7 +29,7 @@ final class PostSortingAreaView: UICollectionReusableView {
   /// 분류
   private var travelThemeChevronView = PostChevronLabel()
   
-  /// 최신순
+  /// 정렬
   private var travelTrendChevronView = PostChevronLabel()
   
   // MARK: - LifeCycle

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
@@ -7,11 +7,6 @@
 
 import UIKit
 
-protocol BasePostCategoryBottomSheetDelegate: AnyObject {
-  associatedtype Category: RawRepresentable
-  func notifySelectedCategory(_ category: Category)
-}
-
 class BasePostCategoryBottomSheet: BaseBottomSheetViewController {
   // MARK: - Properties
   private let contentView: UIView

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
@@ -7,35 +7,9 @@
 
 import UIKit
 
-protocol TravelThemeBottomSheetDelegate: AnyObject {
-  func notifySelectedFilterOption(_ type: PostFilterOptions?)
-}
-
-protocol PostOrderCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
-where Category == TravelOrderType {}
-
 protocol BasePostCategoryBottomSheetDelegate: AnyObject {
   associatedtype Category: RawRepresentable
   func notifySelectedCategory(_ category: Category)
-}
-
-final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
-  init() {
-    super.init(bottomSheetMode: .couldBeFull, titles: TravelOrderType.toKoreanList)
-  }
-  
-  required init?(coder: NSCoder) { nil }
-  
-  weak var delegate: (any PostOrderCategoryBottomSheetDelegate)?
-  
-  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-    super.dismiss(animated: flag, completion: completion)
-    guard 
-      let selectedTitle,
-      let selectedOrderType = TravelOrderType(rawValue: selectedTitle)
-    else { return }
-    delegate?.notifySelectedCategory(selectedOrderType)
-  }
 }
 
 class BasePostCategoryBottomSheet: BaseBottomSheetViewController {

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/BasePostCategoryBottomSheet.swift
@@ -1,5 +1,5 @@
 //
-//  PostFilteringBottomSheetViewController.swift
+//  BasePostCategoryBottomSheet.swift
 //  travelPlan
 //
 //  Created by 양승현 on 2023/09/18.
@@ -8,24 +8,43 @@
 import UIKit
 
 protocol TravelThemeBottomSheetDelegate: AnyObject {
-  func travelThemeBottomSheetViewController(
-    _ viewController: PostFilteringBottomSheetViewController,
-    didSelectTitle title: String?)
+  func notifySelectedFilterOption(_ type: PostFilterOptions?)
 }
 
-final class PostFilteringBottomSheetViewController: BaseBottomSheetViewController {
-  enum Constants {
-    enum TableView {
-      static let cellHeight: CGFloat = 55
-    }
+protocol PostOrderCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
+where Category == TravelOrderType {}
+
+protocol BasePostCategoryBottomSheetDelegate: AnyObject {
+  associatedtype Category: RawRepresentable
+  func notifySelectedCategory(_ category: Category)
+}
+
+final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
+  init() {
+    super.init(bottomSheetMode: .couldBeFull, titles: TravelOrderType.toKoreanList)
   }
   
+  required init?(coder: NSCoder) { nil }
+  
+  weak var delegate: (any PostOrderCategoryBottomSheetDelegate)?
+  
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    super.dismiss(animated: flag, completion: completion)
+    guard 
+      let selectedTitle,
+      let selectedOrderType = TravelOrderType(rawValue: selectedTitle)
+    else { return }
+    delegate?.notifySelectedCategory(selectedOrderType)
+  }
+}
+
+class BasePostCategoryBottomSheet: BaseBottomSheetViewController {
   // MARK: - Properties
   private let contentView: UIView
   
   private lazy var tableView = UITableView(frame: .zero, style: .plain).set {
     $0.translatesAutoresizingMaskIntoConstraints = false
-    $0.rowHeight = Constants.TableView.cellHeight
+    $0.rowHeight = 55
     $0.separatorStyle = .singleLine
     $0.separatorInset = .zero
     $0.register(
@@ -34,56 +53,41 @@ final class PostFilteringBottomSheetViewController: BaseBottomSheetViewControlle
     $0.dataSource = self
     $0.delegate = self
   }
+    
+  private let titles: [String]
   
-  private(set) var sortingType: PostFilterOptions
-  
-  private lazy var titles: [String] = sortingType.subCateogryTitles
-  
-  weak var delegate: TravelThemeBottomSheetDelegate?
-  
-  private var selectedTitle: String?
+  private(set) var selectedTitle: String?
   
   // MARK: - Lifecycle
   init(
     bottomSheetMode: BaseBottomSheetViewController.ContentMode,
-    sortingType: PostFilterOptions
+    titles: [String]
   ) {
     let contentView = UIView(frame: .zero).set {
       $0.translatesAutoresizingMaskIntoConstraints = false
       $0.backgroundColor = .white
     }
     self.contentView = contentView
-    self.sortingType = sortingType
+    self.titles = titles
     super.init(contentView: contentView, mode: bottomSheetMode, radius: 8)
   }
   
   required init?(coder: NSCoder) { nil }
   
   override func viewDidLoad() {
-    guard sortingType.subCateogryTitles != TravelRegion.toKoreanList else {
-      setTableViewPosition()
-      super.viewDidLoad()
-      return
-    }
     super.viewDidLoad()
     setTableViewPosition()
-  }
-  
-  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
-    super.dismiss(animated: flag, completion: completion)
-    delegate?.travelThemeBottomSheetViewController(
-      self,
-      didSelectTitle: selectedTitle)
   }
 }
 
 // MARK: - Private Helpers
-extension PostFilteringBottomSheetViewController {
+extension BasePostCategoryBottomSheet {
   private func setTableViewPosition() {
-    let maximumHeight: CGFloat = CGFloat(titles.count) * Constants.TableView.cellHeight
+    // TODO: - 이거 왜 이렇게 복잡하지? max인 경우를 알아야하네.. BaseBottomSheetVC 간편하게 사용할 수 있도록 시간 날 때 리빌딩
+    let maximumHeight: CGFloat = CGFloat(titles.count) * 55
     contentView.addSubview(tableView)
     var heightConstraint: NSLayoutConstraint
-    if sortingType.subCateogryTitles == TravelRegion.toKoreanList {
+    if titles == TravelRegion.toKoreanList {
       heightConstraint = tableView.heightAnchor.constraint(lessThanOrEqualToConstant: maximumHeight)
     } else {
       heightConstraint = tableView.heightAnchor.constraint(equalToConstant: maximumHeight)
@@ -99,7 +103,7 @@ extension PostFilteringBottomSheetViewController {
 }
 
 // MARK: - UITableViewDataSource
-extension PostFilteringBottomSheetViewController: UITableViewDataSource {
+extension BasePostCategoryBottomSheet: UITableViewDataSource {
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
     return titles.count
   }
@@ -116,9 +120,8 @@ extension PostFilteringBottomSheetViewController: UITableViewDataSource {
 }
 
 // MARK: - UITableViewDelegate
-extension PostFilteringBottomSheetViewController: UITableViewDelegate {
+extension BasePostCategoryBottomSheet: UITableViewDelegate {
   func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-    // TODO: - 서버랑 정해야함. 어떻게 서버에 요청해야할 것인지? ex) "https://...지역/세종" 이런느낌으로 보낼건지 param 정해야함.
     selectedTitle = titles[indexPath.row]
     dismiss(animated: false)
   }

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-protocol PostMainThemeCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
-where Category == TravelMainThemeType {}
+protocol PostMainThemeCategoryBottomSheetDelegate: AnyObject {
+  func notifySelectedMainTheme(_ category: TravelMainThemeType)
+}
 
 final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
   // MARK: - Properties
@@ -41,18 +42,18 @@ final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
     case .season(_):
       guard let season = Season(rawValue: selectedTitle) else { return }
         selectedMainTheme = .season(season)
-    case .region(let travelRegion):
+    case .region(_):
       guard let region = TravelRegion(rawValue: selectedTitle) else { return }
       selectedMainTheme = .region(region)
-    case .travelTheme(let travelTheme):
+    case .travelTheme(_):
       guard let theme = TravelTheme(rawValue: selectedTitle) else { return }
       selectedMainTheme = .travelTheme(theme)
-    case .partner(let travelPartner):
+    case .partner(_):
       guard let partner = TravelPartner(rawValue: selectedTitle) else { return }
       selectedMainTheme = .partner(partner)
     default:
       return
     }
-    delegate?.notifySelectedCategory(selectedMainTheme)
+    delegate?.notifySelectedMainTheme(selectedMainTheme)
   }
 }

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
@@ -1,0 +1,8 @@
+//
+//  PostMainThemeCategoryBottomSheet.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/22/24.
+//
+
+import Foundation

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
@@ -6,3 +6,53 @@
 //
 
 import Foundation
+
+protocol PostMainThemeCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
+where Category == TravelMainThemeType {}
+
+final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
+  // MARK: - Properties
+  private let mainTheme: TravelMainThemeType
+  
+  weak var delegate: (any PostMainThemeCategoryBottomSheetDelegate)?
+  
+  // MARK: - Lifecycle
+  init(mainTheme: TravelMainThemeType) {
+    self.mainTheme = mainTheme
+    var bottomSheetMode: BaseBottomSheetViewController.ContentMode
+    if mainTheme.rawValue == TravelMainThemeType.region(.busan).rawValue {
+      bottomSheetMode = .full
+    } else {
+      bottomSheetMode = .couldBeFull
+    }
+    
+    super.init(bottomSheetMode: bottomSheetMode, titles: mainTheme.titles)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    super.dismiss(animated: flag, completion: completion)
+    guard let selectedTitle else { return }
+    var selectedMainTheme: TravelMainThemeType
+    switch mainTheme {
+    case .season(_):
+      guard let season = Season(rawValue: selectedTitle) else { return }
+        selectedMainTheme = .season(season)
+    case .region(let travelRegion):
+      guard let region = TravelRegion(rawValue: selectedTitle) else { return }
+      selectedMainTheme = .region(region)
+    case .travelTheme(let travelTheme):
+      guard let theme = TravelTheme(rawValue: selectedTitle) else { return }
+      selectedMainTheme = .travelTheme(theme)
+    case .partner(let travelPartner):
+      guard let partner = TravelPartner(rawValue: selectedTitle) else { return }
+      selectedMainTheme = .partner(partner)
+    default:
+      return
+    }
+    delegate?.notifySelectedCategory(selectedMainTheme)
+  }
+}

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostMainThemeCategoryBottomSheet.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 protocol PostMainThemeCategoryBottomSheetDelegate: AnyObject {
-  func notifySelectedMainTheme(_ category: TravelMainThemeType)
+  func notifySelectedMainTheme(_ category: TravelMainThemeType?)
 }
 
 final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
@@ -36,8 +36,11 @@ final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
   
   override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
     super.dismiss(animated: flag, completion: completion)
-    guard let selectedTitle else { return }
-    var selectedMainTheme: TravelMainThemeType
+    guard let selectedTitle else {
+      delegate?.notifySelectedMainTheme(nil)
+      return
+    }
+    var selectedMainTheme: TravelMainThemeType?
     switch mainTheme {
     case .season(_):
       guard let season = Season(rawValue: selectedTitle) else { return }
@@ -52,7 +55,7 @@ final class PostMainThemeCategoryBottomSheet: BasePostCategoryBottomSheet {
       guard let partner = TravelPartner(rawValue: selectedTitle) else { return }
       selectedMainTheme = .partner(partner)
     default:
-      return
+      break
     }
     delegate?.notifySelectedMainTheme(selectedMainTheme)
   }

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
@@ -7,8 +7,9 @@
 
 import UIKit
 
-protocol PostOrderCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
-where Category == TravelOrderType {}
+protocol PostOrderCategoryBottomSheetDelegate: AnyObject {
+  func notifySelectedOrder(_ category: TravelOrderType)
+}
 
 final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
   // MARK: - Properties
@@ -27,6 +28,6 @@ final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
       let selectedTitle,
       let selectedOrderType = TravelOrderType(rawValue: selectedTitle)
     else { return }
-    delegate?.notifySelectedCategory(selectedOrderType)
+    delegate?.notifySelectedOrder(selectedOrderType)
   }
 }

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 protocol PostOrderCategoryBottomSheetDelegate: AnyObject {
-  func notifySelectedOrder(_ category: TravelOrderType)
+  func notifySelectedOrder(_ category: TravelOrderType?)
 }
 
 final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
@@ -27,7 +27,10 @@ final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
     guard
       let selectedTitle,
       let selectedOrderType = TravelOrderType(rawValue: selectedTitle)
-    else { return }
+    else {
+      delegate?.notifySelectedOrder(nil)
+      return
+    }
     delegate?.notifySelectedOrder(selectedOrderType)
   }
 }

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
@@ -5,4 +5,26 @@
 //  Created by 양승현 on 3/22/24.
 //
 
-import Foundation
+import UIKit
+
+protocol PostOrderCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelegate
+where Category == TravelOrderType {}
+
+final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
+  init() {
+    super.init(bottomSheetMode: .couldBeFull, titles: TravelOrderType.toKoreanList)
+  }
+  
+  required init?(coder: NSCoder) { nil }
+  
+  weak var delegate: (any PostOrderCategoryBottomSheetDelegate)?
+  
+  override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+    super.dismiss(animated: flag, completion: completion)
+    guard
+      let selectedTitle,
+      let selectedOrderType = TravelOrderType(rawValue: selectedTitle)
+    else { return }
+    delegate?.notifySelectedCategory(selectedOrderType)
+  }
+}

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
@@ -11,13 +11,15 @@ protocol PostOrderCategoryBottomSheetDelegate: BasePostCategoryBottomSheetDelega
 where Category == TravelOrderType {}
 
 final class PostOrderCategoryBottomSheet: BasePostCategoryBottomSheet {
+  // MARK: - Properties
+  weak var delegate: (any PostOrderCategoryBottomSheetDelegate)?
+  
+  // MARK: - Lifecycle
   init() {
     super.init(bottomSheetMode: .couldBeFull, titles: TravelOrderType.toKoreanList)
   }
   
   required init?(coder: NSCoder) { nil }
-  
-  weak var delegate: (any PostOrderCategoryBottomSheetDelegate)?
   
   override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
     super.dismiss(animated: flag, completion: completion)

--- a/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/BottomSheet/PostOrderCategoryBottomSheet.swift
@@ -1,0 +1,8 @@
+//
+//  PostOrderCategoryBottomSheet.swift
+//  travelPlan
+//
+//  Created by 양승현 on 3/22/24.
+//
+
+import Foundation

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
@@ -32,6 +32,8 @@ enum FeedPostViewControllerState {
   case loadingNextPage
   case unexpectedError(description: String)
   case noMorePage
+  case postFilterLoading
+  case postFilterLoaded
   case none
 }
 
@@ -144,6 +146,11 @@ extension FeedPostViewController: ViewBindCase {
     case .noMorePage:
       print("noMorePage")
     case .viewDidLoad:
+      postView.reloadData()
+    case .postFilterLoading:
+      startIndicator()
+    case .postFilterLoaded:
+      stopIndicator()
       postView.reloadData()
     }
   }

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
@@ -12,6 +12,17 @@ struct FeedPostViewControllerInput {
   let feedRefresh: PassthroughSubject<Void, Never> = .init()
   let nextPage: PassthroughSubject<Void, Never> = .init()
   let viewDidLoad: PassthroughSubject<Void, Never> = .init()
+  let notifiedOrderFilterRequest: PassthroughSubject<TravelOrderType, Never>
+  let notifiedMainThemeFilterRequest: PassthroughSubject<TravelMainThemeType, Never>
+  
+  init(
+    notifiedOrderFilterRequest: PassthroughSubject<TravelOrderType, Never>,
+    notifiedMainThemeFilterRequest: PassthroughSubject<TravelMainThemeType, Never>
+  ) {
+    self.notifiedOrderFilterRequest = notifiedOrderFilterRequest
+    self.notifiedMainThemeFilterRequest = notifiedMainThemeFilterRequest
+  }
+  
 }
 
 enum FeedPostViewControllerState {
@@ -48,7 +59,9 @@ final class FeedPostViewController: UIViewController {
   
   private let mainThemeFilterNotifier = PassthroughSubject<TravelMainThemeType, Never>()
 
-  private let input = Input()
+  private lazy var input = Input(
+    notifiedOrderFilterRequest: orderFilterNotifier,
+    notifiedMainThemeFilterRequest: mainThemeFilterNotifier)
   
   // MARK: - Lifecycle
   init(

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
@@ -17,7 +17,7 @@ struct FeedPostViewControllerInput {
 enum FeedPostViewControllerState {
   case viewDidLoad
   case refresh
-  case nextPage(reloadCompletion: ()->Void)
+  case nextPage(reloadCompletion: () -> Void)
   case loadingNextPage
   case unexpectedError(description: String)
   case noMorePage

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedPostViewController.swift
@@ -43,6 +43,10 @@ final class FeedPostViewController: UIViewController {
   }
   
   private let refresher = UIRefreshControl()
+  
+  private let orderFilterNotifier = PassthroughSubject<TravelOrderType, Never>()
+  
+  private let mainThemeFilterNotifier = PassthroughSubject<TravelMainThemeType, Never>()
 
   private let input = Input()
   
@@ -82,12 +86,16 @@ final class FeedPostViewController: UIViewController {
 
 // MARK: - Helpers
 extension FeedPostViewController {
-  func setDefaultThemeUI() {
-    sortingHeader?.setDefaultThemeUI()
+  func handleOrderTypeFilter(with orderType: TravelOrderType?) {
+    sortingHeader?.setDefaultOrderUI()
+    guard let orderType else { return }
+    orderFilterNotifier.send(orderType)
   }
   
-  func setDefaultOrderUI() {
-    sortingHeader?.setDefaultOrderUI()
+  func handleMainThemeFilter(with mainTheme: TravelMainThemeType?) {
+    sortingHeader?.setDefaultThemeUI()
+    guard let mainTheme else { return }
+    mainThemeFilterNotifier.send(mainTheme)
   }
 }
 

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedViewController.swift
@@ -224,20 +224,14 @@ extension FeedViewController: ViewBindCase {
 // MARK: - PostOrderCategoryBottomSheetDelegate
 extension FeedViewController: PostOrderCategoryBottomSheetDelegate {
   func notifySelectedOrder(_ category: TravelOrderType?) {
-    categoryPageView.setOrderCategoryHeaderDefaultUI()
-    print(category?.rawValue)
-    categoryPageView
-    // TODO: - 서버에서 데이터 요청 후 특정 정렬된 posts로 리로드.
-    // 소분류 let type = viewController.travelThemeType.rawValue
-    // 특정 상세 카테고리 title
+    categoryPageView.handleOrderTypeFilter(with: category)
   }
 }
 
 // MARK: - PostMainThemeCategoryBottomSheetDelegate
 extension FeedViewController: PostMainThemeCategoryBottomSheetDelegate {
   func notifySelectedMainTheme(_ category: TravelMainThemeType?) {
-    print(category?.rawValue)
-    categoryPageView.setMainThemeCategoryHeaderDefaultUI()
+    categoryPageView.handleMainThemeFilter(with: category)
   }
 }
 

--- a/travelPlan/Source/Presentation/Feed/ViewController/FeedViewController.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewController/FeedViewController.swift
@@ -144,6 +144,7 @@ extension FeedViewController {
 
 // MARK: - Actions
 extension FeedViewController {
+  /// PostSortingAreaView의 moreMenuView에서 정렬, 분류 뷰를 클릭시 전달하는 노티를 받습니다.
   @objc func handleNotificaiton(_ noti: Notification) {
     let notiKey = Notification.Name.TravelCategoryDetailSelected
     guard
@@ -156,9 +157,9 @@ extension FeedViewController {
     case .travelOrder:
       // 1. 지금은 일차적으로 모든 경우에 대해서 토탈, 소팅으로만 했는데 이제 cell별로 분류해서 카테고리가 계절인지, 지역탐방인지 등등 파악해야해서
       // 2. postview의 footer에서 라인 과 간격을 10으로 수정했다는데 ,,, 뭔지모르겠어서 다시 확인해봐야해
-      coordinator?.showPostOrderFilteringBottomSheet()
-    case .travelMainTheme(let themeType):
-      coordinator?.showPostMainThemeFilteringBottomSheet(sortingType: themeType)
+      coordinator?.showPostOrderCategoryBottomSheet()
+    case .travelMainTheme(let mainTheme):
+      coordinator?.showPostMainThemeCategoryBottomSheet(mainTheme: mainTheme)
     }
   }
 }
@@ -220,18 +221,23 @@ extension FeedViewController: ViewBindCase {
   }
 }
 
-// MARK: - TravelThemeBottomSheetDelegate
-extension FeedViewController: TravelThemeBottomSheetDelegate {
-  // TODO: - 이것도 그냥 FeedPostVC로 전달하기만하자 여기서 처리하지말구
-  func travelThemeBottomSheetViewController(
-    _ viewController: PostFilteringBottomSheetViewController,
-    didSelectTitle title: String?
-  ) {
-    categoryPageView.setDefaultSortingHeaderUI(from: viewController.sortingType)
-    guard title != nil else { return }
+// MARK: - PostOrderCategoryBottomSheetDelegate
+extension FeedViewController: PostOrderCategoryBottomSheetDelegate {
+  func notifySelectedOrder(_ category: TravelOrderType?) {
+    categoryPageView.setOrderCategoryHeaderDefaultUI()
+    print(category?.rawValue)
+    categoryPageView
     // TODO: - 서버에서 데이터 요청 후 특정 정렬된 posts로 리로드.
     // 소분류 let type = viewController.travelThemeType.rawValue
     // 특정 상세 카테고리 title
+  }
+}
+
+// MARK: - PostMainThemeCategoryBottomSheetDelegate
+extension FeedViewController: PostMainThemeCategoryBottomSheetDelegate {
+  func notifySelectedMainTheme(_ category: TravelMainThemeType?) {
+    print(category?.rawValue)
+    categoryPageView.setMainThemeCategoryHeaderDefaultUI()
   }
 }
 

--- a/travelPlan/Source/Presentation/Feed/ViewModel/CategoryPageViewModel.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewModel/CategoryPageViewModel.swift
@@ -9,21 +9,23 @@ import Foundation
 
 final class CategoryPageViewModel {
   // MARK: - Properties
-  private var travelMainCategory: [TravelMainThemeType] {
-    TravelMainThemeType.allCases
-  }
+  private let travelMainCategoryTitles: [String]
   
-  private lazy var travelMainCategoryTitles: [String] = {
-    travelMainCategory.map { $0.rawValue }
-  }()
+  private let travelCategoryItems: [TravelMainCategoryViewCellInfo]
   
-  private lazy var travelCategoryItems: [TravelMainCategoryViewCellInfo] = travelMainCategory
-    .map {
+  private let postCategoryList: [PostCategory]
+  
+  init() {
+    let mainThemes = TravelMainThemeType.allCases
+    
+    travelMainCategoryTitles = mainThemes.map { $0.rawValue }
+    travelCategoryItems = mainThemes.map {
       .init(cagtegoryTitle: $0.rawValue, imagePath: $0.imagePath)
     }
-  
-  private lazy var postCateogryList: [PostCategory] = travelMainCategory.map {
-    .init(mainTheme: $0, orderBy: .newest)
+    postCategoryList = mainThemes.map {
+      let postCategory = PostCategory(mainTheme: $0, orderBy: .newest)
+      return postCategory
+    }
   }
 }
 
@@ -42,6 +44,6 @@ extension CategoryPageViewModel: CategoryPageViewDataSource {
   }
   
   func postSearchFilterItem(at index: Int) -> PostCategory {
-    return postCateogryList[index]
+    return postCategoryList[index]
   }
 }

--- a/travelPlan/Source/Presentation/Feed/ViewModel/FeedPostViewModel.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewModel/FeedPostViewModel.swift
@@ -55,6 +55,7 @@ class FeedPostViewModel: PostViewModel {
 extension FeedPostViewModel: FeedPostViewModelable {
   func transform(_ input: Input) -> AnyPublisher<State, Never> {
     return Publishers.MergeMany([
+      postFilterLoadingStartSubjectStream(),
       notifiedOrderFilterRequestStream(input),
       notifiedMainThemeFilterRequestStream(input),
       viewDidLoadStream(input),
@@ -67,6 +68,12 @@ extension FeedPostViewModel: FeedPostViewModelable {
 
 // MARK: - Private Helpers
 private extension FeedPostViewModel {
+  func postFilterLoadingStartSubjectStream() -> Output {
+    postFilterLoadingStartSubject.map { _ -> State in
+      return .postFilterLoading
+    }.eraseToAnyPublisher()
+  }
+  
   func notifiedOrderFilterRequestStream(_ input: Input) -> Output {
     return input.notifiedOrderFilterRequest
       .flatMap { [weak self] selectedOrderType in
@@ -75,7 +82,7 @@ private extension FeedPostViewModel {
             .eraseToAnyPublisher()
         }
         self?.userSelectedCategory = PostCategory(mainTheme: mainTheme, orderBy: selectedOrderType)
-        
+        self?.postFilterLoadingStartSubject.send()
         // TODO: - fetchPosts()호출요.
         return Just(State.none).eraseToAnyPublisher()
       }.eraseToAnyPublisher()
@@ -100,6 +107,7 @@ private extension FeedPostViewModel {
         default:
           return Just(State.none).eraseToAnyPublisher()
         }
+        self?.postFilterLoadingStartSubject.send()
         // TODO: - 서버 호출해야함둥..
         return Just(State.none).eraseToAnyPublisher()
       }.eraseToAnyPublisher()

--- a/travelPlan/Source/Presentation/Feed/ViewModel/FeedPostViewModel.swift
+++ b/travelPlan/Source/Presentation/Feed/ViewModel/FeedPostViewModel.swift
@@ -32,7 +32,7 @@ class FeedPostViewModel: PostViewModel {
     return currentPage < totalPageCount
   }
   
-  private let category: PostCategory
+  private var category: PostCategory
   
   private let postUseCase: PostUseCase
   
@@ -49,6 +49,8 @@ class FeedPostViewModel: PostViewModel {
 extension FeedPostViewModel: FeedPostViewModelable {
   func transform(_ input: Input) -> AnyPublisher<State, Never> {
     return Publishers.MergeMany([
+      notifiedOrderFilterRequestStream(input),
+      notifiedMainThemeFilterRequestStream(input),
       viewDidLoadStream(input),
       nextPageStream(input),
       feedRefreshStream(input),
@@ -59,6 +61,33 @@ extension FeedPostViewModel: FeedPostViewModelable {
 
 // MARK: - Private Helpers
 private extension FeedPostViewModel {
+  func notifiedOrderFilterRequestStream(_ input: Input) -> Output {
+    return input.notifiedOrderFilterRequest
+      .map { selectedOrderType in
+        return .none
+      }.eraseToAnyPublisher()
+  }
+  
+  func notifiedMainThemeFilterRequestStream(_ input: Input) -> Output {
+    return input.notifiedMainThemeFilterRequest
+      .map { selectedMainTheme in
+        switch selectedMainTheme {
+        case .partner(let partner):
+          break
+        case .region(let region):
+          break
+        case .season(let season):
+          break
+        case .travelTheme(let theme):
+          break
+
+        default:
+          return .none
+        }
+        return .none
+      }.eraseToAnyPublisher()
+  }
+  
   func viewDidLoadStream(_ input: Input) -> Output {
     return input.viewDidLoad.flatMap { [weak self] _ in
       return self?.fetchPosts()

--- a/travelPlan/travelPlan.xcodeproj/project.pbxproj
+++ b/travelPlan/travelPlan.xcodeproj/project.pbxproj
@@ -171,9 +171,9 @@
 		15259DEB2ACAA9F600C14F62 /* PostSearchFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C07ECC2A13F454005F04CD /* PostSearchFooterView.swift */; };
 		15259DEC2ACAAAB200C14F62 /* LocationSearchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15EF8C042A0829FD0068C744 /* LocationSearchViewController.swift */; };
 		152603D72B97A4BC00634299 /* PostsRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152603D62B97A4BC00634299 /* PostsRequestDTO.swift */; };
-		152834D52BAB4DED00453DD1 /* PostViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152834D42BAB4DED00453DD1 /* PostViewSection.swift */; };
 		152715412BA0D5AE0077D033 /* UserRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152715402BA0D5AE0077D033 /* UserRepository.swift */; };
 		152715452BA0D60F0077D033 /* DefaultOthersProfileRepository.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152715442BA0D60F0077D033 /* DefaultOthersProfileRepository.swift */; };
+		152834D52BAB4DED00453DD1 /* PostViewSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152834D42BAB4DED00453DD1 /* PostViewSection.swift */; };
 		152AD4F02A189CFC008A2A11 /* FavoriteHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD4EF2A189CFC008A2A11 /* FavoriteHeaderView.swift */; };
 		152AD4F62A18B6C3008A2A11 /* FavoriteHeaderImageViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD4F52A18B6C3008A2A11 /* FavoriteHeaderImageViews.swift */; };
 		152AD51B2A1A0447008A2A11 /* FavoriteTableViewAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 152AD51A2A1A0447008A2A11 /* FavoriteTableViewAdapter.swift */; };
@@ -252,6 +252,8 @@
 		1594F53429FD517E00A58F20 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1594F53329FD517E00A58F20 /* SceneDelegate.swift */; };
 		1594F53B29FD517F00A58F20 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53A29FD517F00A58F20 /* Assets.xcassets */; };
 		1594F53E29FD517F00A58F20 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1594F53C29FD517F00A58F20 /* LaunchScreen.storyboard */; };
+		1595B52E2BAD9D5B00DA5039 /* PostOrderCategoryBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1595B52D2BAD9D5B00DA5039 /* PostOrderCategoryBottomSheet.swift */; };
+		1595B5302BAD9DAC00DA5039 /* PostMainThemeCategoryBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1595B52F2BAD9DAC00DA5039 /* PostMainThemeCategoryBottomSheet.swift */; };
 		159958762B0D988400B2E4DC /* Palette.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 159958752B0D988400B2E4DC /* Palette.xcassets */; };
 		159958792B0DC51900B2E4DC /* PostCellWithOneThumbnail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 159958782B0DC51900B2E4DC /* PostCellWithOneThumbnail.swift */; };
 		1599587B2B0DC55700B2E4DC /* PostCellWithTwoThumbnails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1599587A2B0DC55700B2E4DC /* PostCellWithTwoThumbnails.swift */; };
@@ -267,7 +269,6 @@
 		15A0E1A12B97A3FD0047D662 /* PostContainerResponseDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A0E1A02B97A3FD0047D662 /* PostContainerResponseDTO.swift */; };
 		15A4F28B2ACC072A001AA51D /* PrimaryColorToneRoundLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A4F28A2ACC072A001AA51D /* PrimaryColorToneRoundLabel.swift */; };
 		15A4F28D2ACC1025001AA51D /* Toggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A4F28C2ACC1025001AA51D /* Toggable.swift */; };
-		15A4F28F2ACC11E5001AA51D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A4F28E2ACC11E5001AA51D /* ViewController.swift */; };
 		15A7A8EE2B9F6B1D00CA9A79 /* UserDefaultsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A7A8ED2B9F6B1D00CA9A79 /* UserDefaultsManager.swift */; };
 		15A7A8F22B9F6C1700CA9A79 /* UserEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A7A8F12B9F6C1700CA9A79 /* UserEntity.swift */; };
 		15AF2C3E2A1147B100BEE166 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15AF2C3D2A1147B100BEE166 /* UIImage+.swift */; };
@@ -350,7 +351,7 @@
 		15DD40452A5B862D002BC5F8 /* PostViewBottomSheetAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DD40442A5B862D002BC5F8 /* PostViewBottomSheetAdapter.swift */; };
 		15DD40482A5B8752002BC5F8 /* PostFilterOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DD40472A5B8752002BC5F8 /* PostFilterOptions.swift */; };
 		15DDB16F2B04799C001F6EAA /* UITextView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DDB16E2B04799C001F6EAA /* UITextView+.swift */; };
-		15DE36B62AB83DD40030CCCC /* PostFilteringBottomSheetViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE36B52AB83DD40030CCCC /* PostFilteringBottomSheetViewController.swift */; };
+		15DE36B62AB83DD40030CCCC /* BasePostCategoryBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE36B52AB83DD40030CCCC /* BasePostCategoryBottomSheet.swift */; };
 		15DE36B92AB853900030CCCC /* TravelThemeBottomSheetCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15DE36B82AB853900030CCCC /* TravelThemeBottomSheetCell.swift */; };
 		15E155062BAB01F900582E12 /* PostMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15E155052BAB01F900582E12 /* PostMapper.swift */; };
 		15E1550D2BAB47F400582E12 /* BottomNextPageIndicatorCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 15E1550C2BAB47F400582E12 /* BottomNextPageIndicatorCell.xib */; };
@@ -647,9 +648,9 @@
 		151DF1112AEECDDD00D5D55B /* NoticeViewModelable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoticeViewModelable.swift; sourceTree = "<group>"; };
 		1524A4A42BABEAA5002C639A /* MockPostUseCase.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPostUseCase.swift; sourceTree = "<group>"; };
 		152603D62B97A4BC00634299 /* PostsRequestDTO.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostsRequestDTO.swift; sourceTree = "<group>"; };
-		152834D42BAB4DED00453DD1 /* PostViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewSection.swift; sourceTree = "<group>"; };
 		152715402BA0D5AE0077D033 /* UserRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserRepository.swift; sourceTree = "<group>"; };
 		152715442BA0D60F0077D033 /* DefaultOthersProfileRepository.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultOthersProfileRepository.swift; sourceTree = "<group>"; };
+		152834D42BAB4DED00453DD1 /* PostViewSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewSection.swift; sourceTree = "<group>"; };
 		152AD4E72A188D33008A2A11 /* FavoriteTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteTableViewCell.swift; sourceTree = "<group>"; };
 		152AD4ED2A1891DB008A2A11 /* UISpacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UISpacing.swift; sourceTree = "<group>"; };
 		152AD4EF2A189CFC008A2A11 /* FavoriteHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteHeaderView.swift; sourceTree = "<group>"; };
@@ -730,6 +731,8 @@
 		1594F53A29FD517F00A58F20 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		1594F53D29FD517F00A58F20 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		1594F53F29FD517F00A58F20 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1595B52D2BAD9D5B00DA5039 /* PostOrderCategoryBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostOrderCategoryBottomSheet.swift; sourceTree = "<group>"; };
+		1595B52F2BAD9DAC00DA5039 /* PostMainThemeCategoryBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMainThemeCategoryBottomSheet.swift; sourceTree = "<group>"; };
 		159958752B0D988400B2E4DC /* Palette.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Palette.xcassets; sourceTree = "<group>"; };
 		159958782B0DC51900B2E4DC /* PostCellWithOneThumbnail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCellWithOneThumbnail.swift; sourceTree = "<group>"; };
 		1599587A2B0DC55700B2E4DC /* PostCellWithTwoThumbnails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostCellWithTwoThumbnails.swift; sourceTree = "<group>"; };
@@ -745,7 +748,6 @@
 		15A0E1A02B97A3FD0047D662 /* PostContainerResponseDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostContainerResponseDTO.swift; sourceTree = "<group>"; };
 		15A4F28A2ACC072A001AA51D /* PrimaryColorToneRoundLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrimaryColorToneRoundLabel.swift; sourceTree = "<group>"; };
 		15A4F28C2ACC1025001AA51D /* Toggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toggable.swift; sourceTree = "<group>"; };
-		15A4F28E2ACC11E5001AA51D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
 		15A7A8ED2B9F6B1D00CA9A79 /* UserDefaultsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsManager.swift; sourceTree = "<group>"; };
 		15A7A8F12B9F6C1700CA9A79 /* UserEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEntity.swift; sourceTree = "<group>"; };
 		15AF2C3D2A1147B100BEE166 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
@@ -826,7 +828,7 @@
 		15DD40442A5B862D002BC5F8 /* PostViewBottomSheetAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostViewBottomSheetAdapter.swift; sourceTree = "<group>"; };
 		15DD40472A5B8752002BC5F8 /* PostFilterOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFilterOptions.swift; sourceTree = "<group>"; };
 		15DDB16E2B04799C001F6EAA /* UITextView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextView+.swift"; sourceTree = "<group>"; };
-		15DE36B52AB83DD40030CCCC /* PostFilteringBottomSheetViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostFilteringBottomSheetViewController.swift; sourceTree = "<group>"; };
+		15DE36B52AB83DD40030CCCC /* BasePostCategoryBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasePostCategoryBottomSheet.swift; sourceTree = "<group>"; };
 		15DE36B82AB853900030CCCC /* TravelThemeBottomSheetCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TravelThemeBottomSheetCell.swift; sourceTree = "<group>"; };
 		15E155052BAB01F900582E12 /* PostMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostMapper.swift; sourceTree = "<group>"; };
 		15E1550B2BAB47F400582E12 /* BottomNextPageIndicatorCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomNextPageIndicatorCell.swift; sourceTree = "<group>"; };
@@ -1920,6 +1922,16 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		1595B52C2BAD9CB800DA5039 /* BottomSheet */ = {
+			isa = PBXGroup;
+			children = (
+				15DE36B52AB83DD40030CCCC /* BasePostCategoryBottomSheet.swift */,
+				1595B52D2BAD9D5B00DA5039 /* PostOrderCategoryBottomSheet.swift */,
+				1595B52F2BAD9DAC00DA5039 /* PostMainThemeCategoryBottomSheet.swift */,
+			);
+			path = BottomSheet;
+			sourceTree = "<group>";
+		};
 		15A7A8EC2B9F6B0500CA9A79 /* UserDefaultsStorage */ = {
 			isa = PBXGroup;
 			children = (
@@ -1992,12 +2004,12 @@
 		15BED2FC2A08249300F86321 /* ViewController */ = {
 			isa = PBXGroup;
 			children = (
+				1595B52C2BAD9CB800DA5039 /* BottomSheet */,
 				1550D9B02ACB1D740046569B /* DevelopmentViewController.swift */,
 				1550D9AE2ACAFAC10046569B /* FeedPostViewController.swift */,
 				13254FE42A05157900094218 /* FeedViewController.swift */,
 				13254FFA2A08AD8700094218 /* PostSearchViewController.swift */,
 				15F0D1BD2A52940F00D04773 /* PostViewBottomSheetViewController.swift */,
-				15DE36B52AB83DD40030CCCC /* PostFilteringBottomSheetViewController.swift */,
 				13405F652AF4470200382796 /* ReviewWritingViewController.swift */,
 			);
 			path = ViewController;
@@ -2846,7 +2858,7 @@
 				15F3765E2AFBF1A500B3BF35 /* PostDetailCommentHeader.swift in Sources */,
 				151DF0DC2AEE6EB500D5D55B /* NotificationViewController.swift in Sources */,
 				15C1F5482AF2C002005FDA15 /* NotificationViewModel.swift in Sources */,
-				15DE36B62AB83DD40030CCCC /* PostFilteringBottomSheetViewController.swift in Sources */,
+				15DE36B62AB83DD40030CCCC /* BasePostCategoryBottomSheet.swift in Sources */,
 				158BEF772A0E279700C27861 /* BasePostView.swift in Sources */,
 				15EF8C9D2A0A19190068C744 /* TravelMainCategoryViewCell.swift in Sources */,
 				15FC90D62ACC1BB50033A1E5 /* PrimaryColorToneRoundButton.swift in Sources */,
@@ -2867,6 +2879,7 @@
 				15D655822B8E079200466FEC /* UserInfoAPIEndpoint.swift in Sources */,
 				15C1F55A2AF37092005FDA15 /* BaseLabel.swift in Sources */,
 				157ADCA02ACFB33100D37680 /* UIScrollView+.swift in Sources */,
+				1595B52E2BAD9D5B00DA5039 /* PostOrderCategoryBottomSheet.swift in Sources */,
 				13254FE72A05158E00094218 /* SearchViewController.swift in Sources */,
 				15C1F5442AF2BF48005FDA15 /* NotificationViewAdapterDataSource.swift in Sources */,
 				151DF0FC2AEEBA0100D5D55B /* NotificationRepository.swift in Sources */,
@@ -2956,6 +2969,7 @@
 				130369662AEC3AA2007E980C /* NSRange+.swift in Sources */,
 				15CB235B2A109CA4003EAF20 /* PostHeaderContentBottomInfo.swift in Sources */,
 				130304792A24936D00776A0D /* SearchViewModel.swift in Sources */,
+				1595B5302BAD9DAC00DA5039 /* PostMainThemeCategoryBottomSheet.swift in Sources */,
 				13405F712AF6F05300382796 /* ReviewWritingPlanView.swift in Sources */,
 				15FB47D72AC0407D0033AA18 /* PostCategory.swift in Sources */,
 				151BDAD42B16E8EA002F36C3 /* UIGestureRecognizer+Combine.swift in Sources */,

--- a/travelPlan/travelPlan.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/travelPlan/travelPlan.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "55f7ae2735d03d4f573afabebae271bcf7f96c6b10120faaf4f0fb9b1e9826c1",
+  "pins" : [
+    {
+      "identity" : "alamofire",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Alamofire/Alamofire.git",
+      "state" : {
+        "revision" : "3dc6a42c7727c49bf26508e29b0a0b35f9c7e1ad",
+        "version" : "5.8.1"
+      }
+    },
+    {
+      "identity" : "shcoordinator",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SHcommit/SHCoordinator.git",
+      "state" : {
+        "revision" : "97952787b20b81476e7de38ccf3e5bd2e5dced22",
+        "version" : "3.0.3"
+      }
+    },
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "f222cbdf325885926566172f6f5f06af95473158",
+        "version" : "5.6.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/travelPlan/travelPlanTests/Presentation/Profile/MyInformationViewModelTests.swift
+++ b/travelPlan/travelPlanTests/Presentation/Profile/MyInformationViewModelTests.swift
@@ -21,7 +21,12 @@ final class MyInformationViewModelTests: XCTestCase {
   override func setUp() {
     super.setUp()
     let useCase = MockMyProfileUseCase()
-    sut = MyInformationViewModel(myProfileUseCase: useCase)
+    let mockStroage = MockUserStorage()
+    let defaultLoggedInUserRepository = DefaultLoggedInUserRepository(storage: mockStroage)
+    let defaultLoggedInUserUseCase = DefaultLoggedInUserUseCase(loggedInUserRepository: defaultLoggedInUserRepository)
+    sut = MyInformationViewModel(
+      myProfileUseCase: useCase,
+      loggedInUserUseCase: defaultLoggedInUserUseCase)
     input = MyInformationViewModel.Input()
   }
   


### PR DESCRIPTION
🚨 **Your checklist for this pull request** 

- [x]  Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!

- [x]  Check the commit's or even all commits' message styles matches our requested structure.

## 📌 [요약]

*<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요. ㅐㄱ-->*
  
  [Rebuild]
- 피드 정렬 바텀시트 보여주는 로직 간소화
- 카테고리 페이지 뷰 내부에서 페이지 뷰 컨트롤러 FeedPageVC 인스턴스 생성 하는과정을 FeedCoordinator에서 담당하도록 리빌딩 ( FeedPageCoordiantor를 만들었지만 CategoryView에서 소유해야함으로 제거..)

[Feature]
- 정렬 선택시 관련 카테고리의 포스트들 서버한테 호출 후 리로드 구현 ( presentation layer, useCase 연동 )

## 📸  [스크린샷(선택)]
 
<img src="https://github.com/IF-TG/iOS/assets/96910404/5be77f25-b0b8-4842-919d-3aaed0c9049b" width="250">|
|:-:|
|`피드 탭 필터링에 따른 포스트 fetch`|

## ✨ [작업 내용]

### 서버 호출 requset 경우

<img width="1134" alt="image" src="https://github.com/IF-TG/iOS/assets/96910404/efa73f33-c7e0-482c-b03a-8d0a73c6b809">

- feed post list를 서버에서 받아올 때 required는 반드시 요청해야 하는 경우입니다.
- orderMethod는 Doamin - Entity의 TravelOrderType
- mainCategory는 Domain - TravelMainThemeType
- subCategory는 Domain - TravelMainThemeType의 associated value입니다. 
- enum으로 정의됬지만, Data의 Category Mapper함수를 통해서 서버 api 요청 타입에 맞게 변환되야 합니다.

---


### 뷰에서 사용되는 필터링 모델
 
![image](https://github.com/IF-TG/iOS/assets/96910404/981aaecc-71d1-402e-a5b1-2cf50bfc47ce)

피드 화면에서 포스트는 정렬, 분류 두개의 버튼으로 필터링 됩니다.
- 정렬버튼은 **travelOrder**(최신순, 인기순) 바텀시트를 보여주고

- 분류 버튼은 **travelMainTheme**(특정 카테고리 예를들어 계절이라면)
- - 봄, 여름, 가을, 겨울 이 표시된 바텀시트를 보여줍니다.

크게 PostFilterOptions타입은 두 가지이고, 이 두 가지를 기존에는 하나의 객체에서 조건문을 통해 처리더 간편하게 리빌딩 함으로 FeedCoordiantor에서 관련 bottomSheet 뷰 호출로직을 간소화 했습니다.

최대한 공통적인 기능들을 담당하도록 BasePostCategoryBottomSheet객체 선언 후 리빌딩을 하면서 특정 조건이 아닌 이상 많은 분기처리를 줄이게 되었습니다. 

### 로직 흐름

![image](https://github.com/IF-TG/iOS/assets/96910404/555cc81b-89fb-4864-93a3-1a1101c061a5)

바텀시트를 보여줄 때
- TravelOrder인 경우 TravelOrderType 객체의 titles 을 기반으로 (바텀시트 테이블뷰의 데이터 소스 담당하도록 했습니다.
- TravelMainTheme인 경우 TravelMainThemeType 객체의 titles 을 기반으로 바텀시트 테이블뷰 데이터 소스 담당하도록 했습니다.

![image](https://github.com/IF-TG/iOS/assets/96910404/33bed545-343c-4b68-82a0-4e4322da154a)



## 📚 [레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항]

### [Xcode Breakpoint Actions]

- 관련 포스트 (<a href="https://medium.nextlevelswift.com/do-more-with-breakpoints-in-xcode-ios-a54c0fc15c9">개념 링크</a>)


![스크린샷 2024-03-24 오전 2 45 25](https://github.com/IF-TG/iOS/assets/96910404/cdf7a4cd-9fc6-4ad8-85dc-f75fbdb45f9c)

디버깅 상태에서 디버그 중단지점 선정 후 특정 scope에서 멈출 경우 po, p 등으로 scope에서 사용가능한 프로퍼티들의 상태를 확인할 수 있었는데, Xcode BreakPoint Actions를 통해서 매번 디버깅 시마다 같은 명령어 사용하지 않고 스레드가 특정 scope 지날때 해당 프로퍼티의 상태 변화나 다른 값 대입 등을 할 수 있습니다.

 ![2024-03-242 44 15-ezgif com-video-to-gif-converter](https://github.com/IF-TG/iOS/assets/96910404/37e9981a-9ed7-44ab-aeb8-24e6a1d3c036)

디버깅 체크를 했지만 skip할수도 있습니다. VM의 Stream()함수가 실행될 때 브래이크 체크 해도 skip하도록 설정했습니다. 그런데 로컬 환경에서만 저장이 된다고 합니다..

다음은 로깅..?!?